### PR TITLE
docs: update README.md covering first time windows usage instructions 

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ If setting up backrest manually it's recommended to install the binary to `/usr/
 
 ## Running on Windows
 
-Download a Windows release from the [releases page](https://github.com/garethgeorge/backrest/releases) and install it to `C:\Program Files\Backrest\backrest.exe` (create the path if it does not exist).
+Download a Windows release from the [releases page](https://github.com/garethgeorge/backrest/releases) and install it to `C:\Program Files\Backrest\backrest.exe` (create the path if it does not exist). The binary should be run as administrator on first launch, otherwise the restic installation will fail and the process will terminate.
 
 To run the binary on login, create a shortcut to the binary and place it in the `shell:startup` folder. See [this windows support article](https://support.microsoft.com/en-us/windows/add-an-app-to-run-automatically-at-startup-in-windows-10-150da165-dcd9-7230-517b-cf3c295d89dd) for more details.
 


### PR DESCRIPTION
Added instructions for first launch of binary on Windows - restic install will fail and close the process if backrest.exe is not launched as administrator the first time.