### PR TITLE
chore: add devcontainer and vscode launch configurations

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,22 @@
+## Based on microsoft go devcontainer - https://github.com/microsoft/vscode-dev-containers/blob/v0.205.2/containers/go/.devcontainer/Dockerfile
+# [Choice] Go version (use -bullseye variants on local arm64/Apple Silicon): 1, 1.16, 1.17, 1-bullseye, 1.16-bullseye, 1.17-bullseye, 1-buster, 1.16-buster, 1.17-buster
+ARG VARIANT=1-bullseye
+FROM mcr.microsoft.com/vscode/devcontainers/go:${VARIANT}
+
+# [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
+ARG NODE_VERSION="none"
+RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
+
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends protobuf-compiler
+
+USER vscode
+
+RUN go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest \
+    && go install github.com/bufbuild/buf/cmd/buf@v1.27.2 \
+    && go install github.com/fullstorydev/grpcurl/cmd/grpcurl@latest \
+    && go install google.golang.org/protobuf/cmd/protoc-gen-go@latest \
+    && go install connectrpc.com/connect/cmd/protoc-gen-connect-go@latest \
+    && go install github.com/GeertJohan/go.rice/rice@latest \
+    && go install github.com/goreleaser/goreleaser@latest \
+    && npm install -g @bufbuild/protoc-gen-es @connectrpc/protoc-gen-connect-es

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,51 @@
+{
+	"name": "Go",
+	"build": {
+		"dockerfile": "Dockerfile",
+		"args": {
+			// Update the VARIANT arg to pick a version of Go: 1, 1.16, 1.17
+			// Append -bullseye or -buster to pin to an OS version.
+			// Use -bullseye variants on local arm64/Apple Silicon.
+			"VARIANT": "1-1.21-bookworm",
+			// Options
+			"NODE_VERSION": "lts/*"
+		}
+	},
+	"runArgs": [
+		"--cap-add=SYS_PTRACE",
+		"--security-opt",
+		"seccomp=unconfined"
+	],
+	"customizations": {
+		"vscode": {
+			// Set *default* container specific settings.json values on container create.
+			"settings": {
+				"go.toolsManagement.checkForUpdates": "local",
+				"go.useLanguageServer": true,
+				"go.gopath": "/go",
+				"go.goroot": "/usr/local/go",
+				"typescript.tsdk": "webui/node_modules/typescript/lib",
+				"typescript.enablePromptUseWorkspaceTsdk": true,
+				"gitlens.telemetry.enabled": false
+			},
+			// Add the IDs of extensions you want installed when the container is created.
+			"extensions": [
+				"golang.Go",
+				"ms-azuretools.vscode-docker",
+				"mhutchie.git-graph",
+				"eamodio.gitlens",
+				"donjayamanne.githistory",
+				"esbenp.prettier-vscode",
+				"iulian-radu-at.vscode-tasks-sidebar"
+			]
+		}
+	},
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "go version",
+	
+	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "vscode"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ backrest
 backrest-*
 dist
 backrest.exe
+__debug_bin

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,36 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Debug Go backend",
+            "type": "go",
+            "request": "launch",
+            "mode": "debug",
+            "program": "${workspaceFolder}/backrest.go",
+            "output": "__debug_bin",
+            "preLaunchTask": "Build Webui",
+        },
+        {
+            "type": "chrome",
+            "request": "launch",
+            "preLaunchTask": "Parcel",
+            "postDebugTask": "Terminate Parcel",
+            "name": "Debug TS frontend",
+            "url": "http://localhost:1234",
+            "webRoot": "${workspaceFolder}/webui/src/",
+            "sourceMapPathOverrides": {
+                "../*": "${webRoot}/*"
+            }
+        }
+    ],
+    "compounds": [
+        {
+            "name": "Debug Backrest (backend+frontend)",
+            "configurations": [
+                "Debug Go backend",
+                "Debug TS frontend"
+            ],
+            "stopAll": true
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,51 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "npm i",
+            "type": "shell",
+            "command": "cd webui && npm i",
+        },
+        {
+            "label": "Parcel",
+            "type": "npm",
+            "script": "start",
+            "dependsOn": "npm i",
+            "isBackground": true,
+            "problemMatcher": {
+                "background": {
+                    "activeOnStart": true,
+                    "beginsPattern": "parcel serve",
+                    "endsPattern": "Built in"
+                },
+                "pattern": {
+                    "regexp": ".*"
+                }
+            },
+            "path": "webui"
+        },
+        {
+            "label": "Build Webui",
+            "type": "npm",
+            "script": "build",
+            "path": "webui",
+            "group": "build",
+            "problemMatcher": [],
+            "dependsOn": "npm i"
+        },
+         {
+            "label": "Terminate Parcel",
+            "command": "echo ${input:terminate}",
+            "type": "shell",
+            "problemMatcher": []
+          }
+    ],
+    "inputs": [
+        {
+          "id": "terminate",
+          "type": "command",
+          "command": "workbench.action.tasks.terminate",
+          "args": "Parcel"
+        }
+      ]
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,3 +29,15 @@ npm install -g @bufbuild/protoc-gen-es @connectrpc/protoc-gen-connect-es
 (cd webui && npm i && npm run build)
 (cd cmd/backrest && go build .)
 ```
+
+## Using VSCode Dev Containers
+
+You can also use VSCode with `Dev Containers` extension to quickly get up and running with a working development and debugging environment.
+
+0. Make sure Docker and VSCode with Dev Containers extension is installed
+1. Clone this repository
+2. Open this folder in VSCode
+3. When propmpted, click on `Open in Container` button, or run `> Dev Containers: Rebuild and Reopen in Containers` command
+4. When container is started, go to `Run and Debug`, choose `Debug Backrest (backend+frontend)` and run it
+
+Provided launch configuration has hot reload for typescript frontend.


### PR DESCRIPTION
I added VSCode Dev Container configuration, which adds effortless dev environment setup for those who use VSCode and Docker.

It includes VSCode launch configurations for backend and frontend.

From what I tested, all the core dependencies are installed during creation of the container, and npm packages are installed when launching project.

Maybe it could be improved slightly to wait for backend to start before starting frontend, but as I see it, it is not that important.

Here is a short video on how I start it in a few minutes.

[Screencast from 2024-02-24 03-33-37.webm](https://github.com/garethgeorge/backrest/assets/1036439/f1ac73f9-1047-4265-aa66-6baf36f30075)

I tested only on Linux but it should work on Windows and MacOS as well, of course it starts it in a Linux container. Still, I guess most people would run Backrest on a Linux server.