### PR TITLE
feat: check for basic auth (#110)

### DIFF
--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -17,6 +17,17 @@ const UserContextKey contextKey = "user"
 
 func RequireAuthentication(h http.Handler, auth *Authenticator) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		username, password, usesBasicAuth := r.BasicAuth()
+		if usesBasicAuth {
+			user, err := auth.Login(username, password)
+			if err == nil {
+				ctx := context.WithValue(r.Context(), UserContextKey, user)
+				h.ServeHTTP(w, r.WithContext(ctx))
+				return
+			}
+		}
+
 		token, err := ParseBearerToken(r.Header.Get("Authorization"))
 		if err != nil {
 			http.Error(w, "Unauthorized (No Authorization Header)", http.StatusUnauthorized)


### PR DESCRIPTION
Added a simple check for HTTP Basic authorization. Seems to work fine with Authentik SSO passing the auth header.

This does not add `WWW-Authenticate` header since it normally expects to receive Bearer auth for JWT.

I am not familiar with go, so I presume that `bcrypt.CompareHashAndPassword` takes care of timing attacks and I don't have to add `ConstantTimeCompare` myself. Please correct me if I am wrong.

Maybe adding rate limiting for brute force detection would be a good idea. Should it be added only for Basic auth, or is it relevant for Bearer token as well?