### PR TITLE
fix: install rclone with apk for alpine image

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,8 +1,4 @@
-FROM rclone/rclone:1.65 as rclone
-
-FROM alpine:latest
-COPY --from=rclone /usr/local/bin/rclone /usr/local/bin/rclone
-RUN apk --no-cache add ca-certificates curl bash 
+RUN apk --no-cache add ca-certificates curl bash rclone
 RUN mkdir -p /tmp
 
 ENTRYPOINT ["/backrest"]


### PR DESCRIPTION
Alpine is very much up to date with rclone. Using their provided rclone will probably be more stable due for lack of library and dependency issues.