### PR TITLE
feat: automatically remove Apples quarantine flag

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -74,6 +74,7 @@ if [ "$OS" = "Darwin" ]; then
   install_unix
   create_launchd_plist
   enable_launchd_plist
+  sudo xattr -r -d com.apple.quarantine /usr/local/bin/backrest # remove quarantine flag
 elif [ "$OS" = "Linux" ]; then
   echo "Installing on Linux"
   install_unix


### PR DESCRIPTION
Apple usually puts a quarantine flag on downloaded binaries, that are not signed. This prevents execution of the file. This PR adds a command to the `install.sh` file, to automatically remove the quarantine flag of the installed binary.

*tested on macOS 14.x*