### PR TITLE
Add homebrew support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,7 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_BREW_TOKEN: ${{ secrets.GH_BREW_TOKEN }}
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v3

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -146,6 +146,8 @@ brews:
 
     service: |
       run opt_bin/"backrest"
+      error_log_path var/"log/backrest.log"
+      log_path var/"log/backrest.log"
 
 changelog:
   sort: asc

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -132,7 +132,7 @@ brews:
   - name: backrest
     homepage: https://github.com/garethgeorge/backrest
 
-    url_template: "https://github.com/garethgeorge/backrest/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
+    url_template: "https://github.com/johnmaguire/backrest/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
 
     commit_author:
       name: goreleaserbot

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -144,30 +144,7 @@ brews:
       branch: main
       token: "{{ .Env.GH_BREW_TOKEN }}"
 
-    plist: |
-      <?xml version="1.0" encoding="UTF-8"?>
-      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-      <plist version="1.0">
-      <dict>
-          <key>Label</key>
-          <string>com.backrest</string>
-          <key>ProgramArguments</key>
-          <array>
-          <string>/usr/local/bin/backrest</string>
-          </array>
-          <key>KeepAlive</key>
-          <true/>
-          <key>StandardOutPath</key>
-          <string>/tmp/backrest.log</string>
-          <key>StandardErrorPath</key>
-          <string>/tmp/backrest.log</string>
-          <key>EnvironmentVariables</key>
-          <dict>
-              <key>PATH</key>
-              <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
-          </dict>
-      </dict>
-      </plist>
+    service: backrest
 
 changelog:
   sort: asc

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -144,7 +144,8 @@ brews:
       branch: main
       token: "{{ .Env.GH_BREW_TOKEN }}"
 
-    service: backrest
+    service: |
+      run opt_bin/"backrest"
 
 changelog:
   sort: asc

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -63,7 +63,7 @@ archives:
 
 dockers:
   - image_templates:
-      - jmaguire/backrest:{{ .Tag }}-alpine-amd64
+      - garethgeorge/backrest:{{ .Tag }}-alpine-amd64
     dockerfile: Dockerfile.alpine
     use: buildx
     build_flag_templates:
@@ -71,7 +71,7 @@ dockers:
       - "--platform=linux/amd64"
 
   - image_templates:
-      - jmaguire/backrest:{{ .Tag }}-alpine-arm64
+      - garethgeorge/backrest:{{ .Tag }}-alpine-arm64
     dockerfile: Dockerfile.alpine
     goarch: arm64
     use: buildx
@@ -80,7 +80,7 @@ dockers:
       - "--platform=linux/arm64/v8"
 
   - image_templates:
-      - jmaguire/backrest:{{ .Tag }}-scratch-arm64
+      - garethgeorge/backrest:{{ .Tag }}-scratch-arm64
     dockerfile: Dockerfile.scratch
     goarch: arm64
     use: buildx
@@ -89,7 +89,7 @@ dockers:
       - "--platform=linux/arm64/v8"
 
   - image_templates:
-      - jmaguire/backrest:{{ .Tag }}-scratch-amd64
+      - garethgeorge/backrest:{{ .Tag }}-scratch-amd64
     dockerfile: Dockerfile.scratch
     use: buildx
     build_flag_templates:
@@ -97,7 +97,7 @@ dockers:
       - "--platform=linux/amd64"
 
   - image_templates:
-      - jmaguire/backrest:{{ .Tag }}-scratch-armv6
+      - garethgeorge/backrest:{{ .Tag }}-scratch-armv6
     dockerfile: Dockerfile.scratch
     use: buildx
     build_flag_templates:
@@ -105,41 +105,41 @@ dockers:
       - "--platform=linux/arm/v6"
 
 docker_manifests:
-  - name_template: "jmaguire/backrest:latest"
+  - name_template: "garethgeorge/backrest:latest"
     image_templates:
-      - "jmaguire/backrest:{{ .Tag }}-alpine-amd64"
-      - "jmaguire/backrest:{{ .Tag }}-alpine-arm64"
-  - name_template: "jmaguire/backrest:{{ .Tag }}"
+      - "garethgeorge/backrest:{{ .Tag }}-alpine-amd64"
+      - "garethgeorge/backrest:{{ .Tag }}-alpine-arm64"
+  - name_template: "garethgeorge/backrest:{{ .Tag }}"
     image_templates:
-      - "jmaguire/backrest:{{ .Tag }}-alpine-amd64"
-      - "jmaguire/backrest:{{ .Tag }}-alpine-arm64"
-  - name_template: "jmaguire/backrest:latest-alpine"
+      - "garethgeorge/backrest:{{ .Tag }}-alpine-amd64"
+      - "garethgeorge/backrest:{{ .Tag }}-alpine-arm64"
+  - name_template: "garethgeorge/backrest:latest-alpine"
     image_templates:
-      - "jmaguire/backrest:{{ .Tag }}-alpine-amd64"
-      - "jmaguire/backrest:{{ .Tag }}-alpine-arm64"
-  - name_template: "jmaguire/backrest:scratch"
+      - "garethgeorge/backrest:{{ .Tag }}-alpine-amd64"
+      - "garethgeorge/backrest:{{ .Tag }}-alpine-arm64"
+  - name_template: "garethgeorge/backrest:scratch"
     image_templates:
-      - "jmaguire/backrest:{{ .Tag }}-scratch-amd64"
-      - "jmaguire/backrest:{{ .Tag }}-scratch-arm64"
-      - "jmaguire/backrest:{{ .Tag }}-scratch-armv6"
-  - name_template: "jmaguire/backrest:{{ .Tag }}-scratch"
+      - "garethgeorge/backrest:{{ .Tag }}-scratch-amd64"
+      - "garethgeorge/backrest:{{ .Tag }}-scratch-arm64"
+      - "garethgeorge/backrest:{{ .Tag }}-scratch-armv6"
+  - name_template: "garethgeorge/backrest:{{ .Tag }}-scratch"
     image_templates:
-      - "jmaguire/backrest:{{ .Tag }}-scratch-amd64"
-      - "jmaguire/backrest:{{ .Tag }}-scratch-arm64"
-      - "jmaguire/backrest:{{ .Tag }}-scratch-armv6"
+      - "garethgeorge/backrest:{{ .Tag }}-scratch-amd64"
+      - "garethgeorge/backrest:{{ .Tag }}-scratch-arm64"
+      - "garethgeorge/backrest:{{ .Tag }}-scratch-armv6"
 
 brews:
   - name: backrest
     homepage: https://github.com/garethgeorge/backrest
 
-    url_template: "https://github.com/johnmaguire/backrest/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
+    url_template: "https://github.com/garethgeorge/backrest/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
 
     commit_author:
       name: goreleaserbot
       email: bot@goreleaser.com
 
     repository:
-      owner: johnmaguire
+      owner: garethgeorge
       name: homebrew-backrest-tap
       branch: main
       token: "{{ .Env.GH_BREW_TOKEN }}"
@@ -156,5 +156,5 @@ changelog:
 
 release:
   github:
-    owner: johnmaguire
+    owner: garethgeorge
     name: backrest

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -63,7 +63,7 @@ archives:
 
 dockers:
   - image_templates:
-      - garethgeorge/backrest:{{ .Tag }}-alpine-amd64
+      - jmaguire/backrest:{{ .Tag }}-alpine-amd64
     dockerfile: Dockerfile.alpine
     use: buildx
     build_flag_templates:
@@ -71,7 +71,7 @@ dockers:
       - "--platform=linux/amd64"
 
   - image_templates:
-      - garethgeorge/backrest:{{ .Tag }}-alpine-arm64
+      - jmaguire/backrest:{{ .Tag }}-alpine-arm64
     dockerfile: Dockerfile.alpine
     goarch: arm64
     use: buildx
@@ -80,7 +80,7 @@ dockers:
       - "--platform=linux/arm64/v8"
 
   - image_templates:
-      - garethgeorge/backrest:{{ .Tag }}-scratch-arm64
+      - jmaguire/backrest:{{ .Tag }}-scratch-arm64
     dockerfile: Dockerfile.scratch
     goarch: arm64
     use: buildx
@@ -89,7 +89,7 @@ dockers:
       - "--platform=linux/arm64/v8"
 
   - image_templates:
-      - garethgeorge/backrest:{{ .Tag }}-scratch-amd64
+      - jmaguire/backrest:{{ .Tag }}-scratch-amd64
     dockerfile: Dockerfile.scratch
     use: buildx
     build_flag_templates:
@@ -97,7 +97,7 @@ dockers:
       - "--platform=linux/amd64"
 
   - image_templates:
-      - garethgeorge/backrest:{{ .Tag }}-scratch-armv6
+      - jmaguire/backrest:{{ .Tag }}-scratch-armv6
     dockerfile: Dockerfile.scratch
     use: buildx
     build_flag_templates:
@@ -105,28 +105,28 @@ dockers:
       - "--platform=linux/arm/v6"
 
 docker_manifests:
-  - name_template: "garethgeorge/backrest:latest"
+  - name_template: "jmaguire/backrest:latest"
     image_templates:
-      - "garethgeorge/backrest:{{ .Tag }}-alpine-amd64"
-      - "garethgeorge/backrest:{{ .Tag }}-alpine-arm64"
-  - name_template: "garethgeorge/backrest:{{ .Tag }}"
+      - "jmaguire/backrest:{{ .Tag }}-alpine-amd64"
+      - "jmaguire/backrest:{{ .Tag }}-alpine-arm64"
+  - name_template: "jmaguire/backrest:{{ .Tag }}"
     image_templates:
-      - "garethgeorge/backrest:{{ .Tag }}-alpine-amd64"
-      - "garethgeorge/backrest:{{ .Tag }}-alpine-arm64"
-  - name_template: "garethgeorge/backrest:latest-alpine"
+      - "jmaguire/backrest:{{ .Tag }}-alpine-amd64"
+      - "jmaguire/backrest:{{ .Tag }}-alpine-arm64"
+  - name_template: "jmaguire/backrest:latest-alpine"
     image_templates:
-      - "garethgeorge/backrest:{{ .Tag }}-alpine-amd64"
-      - "garethgeorge/backrest:{{ .Tag }}-alpine-arm64"
-  - name_template: "garethgeorge/backrest:scratch"
+      - "jmaguire/backrest:{{ .Tag }}-alpine-amd64"
+      - "jmaguire/backrest:{{ .Tag }}-alpine-arm64"
+  - name_template: "jmaguire/backrest:scratch"
     image_templates:
-      - "garethgeorge/backrest:{{ .Tag }}-scratch-amd64"
-      - "garethgeorge/backrest:{{ .Tag }}-scratch-arm64"
-      - "garethgeorge/backrest:{{ .Tag }}-scratch-armv6"
-  - name_template: "garethgeorge/backrest:{{ .Tag }}-scratch"
+      - "jmaguire/backrest:{{ .Tag }}-scratch-amd64"
+      - "jmaguire/backrest:{{ .Tag }}-scratch-arm64"
+      - "jmaguire/backrest:{{ .Tag }}-scratch-armv6"
+  - name_template: "jmaguire/backrest:{{ .Tag }}-scratch"
     image_templates:
-      - "garethgeorge/backrest:{{ .Tag }}-scratch-amd64"
-      - "garethgeorge/backrest:{{ .Tag }}-scratch-arm64"
-      - "garethgeorge/backrest:{{ .Tag }}-scratch-armv6"
+      - "jmaguire/backrest:{{ .Tag }}-scratch-amd64"
+      - "jmaguire/backrest:{{ .Tag }}-scratch-arm64"
+      - "jmaguire/backrest:{{ .Tag }}-scratch-armv6"
 
 brews:
   - name: backrest

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -142,6 +142,7 @@ brews:
       owner: johnmaguire
       name: backrest-tap
       branch: main
+      token: "{{ .Env.GH_BREW_TOKEN }}"
 
     plist: |
       <?xml version="1.0" encoding="UTF-8"?>

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -128,6 +128,46 @@ docker_manifests:
       - "garethgeorge/backrest:{{ .Tag }}-scratch-arm64"
       - "garethgeorge/backrest:{{ .Tag }}-scratch-armv6"
 
+brews:
+  - name: backrest
+    homepage: https://github.com/garethgeorge/backrest
+
+    url_template: "https://github.com/garethgeorge/backrest/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
+
+    commit_author:
+      name: goreleaserbot
+      email: bot@goreleaser.com
+
+    repository:
+      owner: johnmaguire
+      name: backrest-tap
+      branch: main
+
+    plist: |
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+      <plist version="1.0">
+      <dict>
+          <key>Label</key>
+          <string>com.backrest</string>
+          <key>ProgramArguments</key>
+          <array>
+          <string>/usr/local/bin/backrest</string>
+          </array>
+          <key>KeepAlive</key>
+          <true/>
+          <key>StandardOutPath</key>
+          <string>/tmp/backrest.log</string>
+          <key>StandardErrorPath</key>
+          <string>/tmp/backrest.log</string>
+          <key>EnvironmentVariables</key>
+          <dict>
+              <key>PATH</key>
+              <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+          </dict>
+      </dict>
+      </plist>
+
 changelog:
   sort: asc
   filters:
@@ -137,5 +177,5 @@ changelog:
 
 release:
   github:
-    owner: garethgeorge
+    owner: johnmaguire
     name: backrest

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -140,7 +140,7 @@ brews:
 
     repository:
       owner: johnmaguire
-      name: backrest-tap
+      name: homebrew-backrest-tap
       branch: main
       token: "{{ .Env.GH_BREW_TOKEN }}"
 


### PR DESCRIPTION
I took a stab at #193. It seems to work. You need a PAT with repo permissions, and a repository that starts with `homebrew-` (e.g. `homebrew-backrest-tap`.) That's pretty much it.

You can see the formula it created here: https://github.com/johnmaguire/homebrew-backrest-tap

You can install it with `brew install johnmaguire/backrest-tap/backrest`. To enable the service, run `brew service start backrest`. I tried running the service as root, but got the following error, and I'm out of time to look at this for now:

```
panic: couldn't determine home directory: $HOME is not defined

goroutine 1 [running]:
github.com/garethgeorge/backrest/internal/config.getHomeDir()
	/home/runner/work/backrest/backrest/internal/config/environment.go:80 +0x68
github.com/garethgeorge/backrest/internal/config.DataDir()
	/home/runner/work/backrest/backrest/internal/config/environment.go:54 +0x98
github.com/garethgeorge/backrest/internal/resticinstaller.FindOrInstallResticBinary()
	/home/runner/work/backrest/backrest/internal/resticinstaller/resticinstaller.go:243 +0x3fc
main.main()
	/home/runner/work/backrest/backrest/backrest.go:38 +0x74
```

Alternatively, we could try to submit a formula to Homebrew core. This could be nice, as then users could just `brew install backrest`. I don't know how long the approval process takes though, so it might be nice to have a tap in the meantime anyway. A core formula would need to build from source: https://docs.brew.sh/Acceptable-Formulae