### PR TITLE
Open docs links in a new tab

### DIFF
--- a/webui/src/views/AddRepoModal.tsx
+++ b/webui/src/views/AddRepoModal.tsx
@@ -211,7 +211,7 @@ export const AddRepoModal = ({
                   <li>SFTP e.g. sftp://user@host:/repo-path</li>
                   <li>
                     See{" "}
-                    <a href="https://restic.readthedocs.io/en/latest/030_preparing_a_new_repo.html#preparing-a-new-repository">
+                    <a href="https://restic.readthedocs.io/en/latest/030_preparing_a_new_repo.html#preparing-a-new-repository" target="_blank">
                       restic docs
                     </a>{" "}
                     for more info.
@@ -384,7 +384,7 @@ export const AddRepoModal = ({
                   <span>
                     The schedule on which prune operations are run for this
                     repository. Read{" "}
-                    <a href="https://restic.readthedocs.io/en/stable/060_forget.html#customize-pruning">
+                    <a href="https://restic.readthedocs.io/en/stable/060_forget.html#customize-pruning" target="_blank">
                       the restic docs on customizing prune operations
                     </a>{" "}
                     for more details.

--- a/webui/src/views/GettingStartedGuide.tsx
+++ b/webui/src/views/GettingStartedGuide.tsx
@@ -25,13 +25,13 @@ export const GettingStartedGuide = () => {
           </li>
           <li>
             See{" "}
-            <a href="https://restic.readthedocs.io/en/latest/030_preparing_a_new_repo.html">
+            <a href="https://restic.readthedocs.io/en/latest/030_preparing_a_new_repo.html" target="_blank">
               the restic docs on preparing a new repository
             </a>{" "}
             for details about available repository types and how they can be
             configured.
           </li>
-          <li>See <a href="https://github.com/garethgeorge/backrest/wiki">the Backrest wiki</a> for instructions on how to configure Backrest.</li>
+          <li>See <a href="https://github.com/garethgeorge/backrest/wiki" target="_blank">the Backrest wiki</a> for instructions on how to configure Backrest.</li>
         </ul>
         <Divider orientation="left">Tips</Divider>
         <ul>


### PR DESCRIPTION
Some docs links already did this, this makes the rest of them match.

I was worried when I clicked on one of the links in a form tooltip and the page navigated away that I might've lost what I'd typed in.