### PR TITLE
Make repo password required

### DIFF
--- a/webui/src/views/AddRepoModal.tsx
+++ b/webui/src/views/AddRepoModal.tsx
@@ -244,6 +244,12 @@ export const AddRepoModal = ({
                   hasFeedback
                   name="password"
                   validateTrigger={["onChange", "onBlur"]}
+                  rules={[
+                    {
+                      required: true,
+                      message: "Please input repo password",
+                    },
+                  ]}
                 >
                   <Input disabled={!!template} />
                 </Form.Item>


### PR DESCRIPTION
Currently, there's no indication that a password is required. If you try to submit the form without one, you get an error flash message:

![Screenshot 2024-04-05 at 01-09-41 Backrest](https://github.com/garethgeorge/backrest/assets/440033/1bf15162-149b-4d91-ad9c-48d98c313f8b)

This PR makes it so you can't submit the form until a password is entered (a single character password is accepted.) It also adds a warning if you click off the field without entering a value.

![Screenshot 2024-04-05 at 01-07-24 Backrest](https://github.com/garethgeorge/backrest/assets/440033/28898bdd-fb24-480c-bdd4-05f2ea1240f7)

Unfortunately I could not figure out how to get the Password label to show the required symbol...