### PR TITLE
fix: use C:\Program Files\backrest on both x64 and 32-bit

### DIFF
--- a/internal/resticinstaller/resticinstaller.go
+++ b/internal/resticinstaller/resticinstaller.go
@@ -242,10 +242,7 @@ func FindOrInstallResticBinary() (string, error) {
 	// Check for restic installation in data directory.
 	resticInstallPath := path.Join(config.DataDir(), resticBinName)
 	if runtime.GOOS == "windows" {
-		programFiles := os.Getenv("programfiles(x86)")
-		if programFiles == "" {
-			programFiles = os.Getenv("programfiles")
-		}
+		programFiles := os.Getenv("programfiles")
 		resticInstallPath = path.Join(programFiles, "restic", resticBinName)
 	}
 

--- a/internal/resticinstaller/resticinstaller.go
+++ b/internal/resticinstaller/resticinstaller.go
@@ -243,7 +243,7 @@ func FindOrInstallResticBinary() (string, error) {
 	resticInstallPath := path.Join(config.DataDir(), resticBinName)
 	if runtime.GOOS == "windows" {
 		programFiles := os.Getenv("programfiles")
-		resticInstallPath = path.Join(programFiles, "restic", resticBinName)
+		resticInstallPath = path.Join(programFiles, "backrest", resticBinName)
 	}
 
 	// Install restic if not found.


### PR DESCRIPTION
While working on #201, I noticed that this code returned `C:\Program Files (x86)` on 64-bit systems, and `C:\Program Files` on 32-bit systems. However, the code downloads a 64-bit binary on 64-bit machines, so it should go in `C:\Program Files` also.

This PR doesn't try to clean up the old file, in case it is in use by another script on the system.

I do wonder if `C:\Program Files\restic` is the best place to install it - were restic to create an installer, it's plausible they would use that as their own install directory. It may be a little safer for backrest to install it into its own program directory, or perhaps some kind of %AppData% directory. 🤷 