### PR TITLE
fix: install.sh was calling systemctl on Darwin

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -5,11 +5,13 @@ cd "$(dirname "$0")" # cd to the directory of this script
 install_or_update_unix() {
   if systemctl is-active --quiet backrest; then
     sudo systemctl stop backrest
-    echo "Updating backrest in /usr/local/bin"
-  else
-    echo "Installing backrest to /usr/local/bin"
+    echo "Paused backrest for update"
   fi
-  
+  install_unix
+}
+
+install_unix() {
+  echo "Installing backrest to /usr/local/bin"
   sudo mkdir -p /usr/local/bin
 
   sudo cp $(ls -1 backrest | head -n 1) /usr/local/bin


### PR DESCRIPTION
In attempting to upgrade to 0.17.2 on MacOS, I noticed errors when running install.sh. It appears that the changes in be09303 broke the Darwin install. I restore the `install_unix()` function, which had be renamed, to contain the common code, and left the Linux-specific code in `install_or_update_unix()`. 

I haven't tested on Linux, but the change is small enough that I think I haven't broken anything.