### PR TITLE
ci(docs): Added broken link detection to docs deploy workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -39,6 +39,12 @@ jobs:
         with:
           path: ./docs/.output/public
 
+      - name: Check for broken links
+        uses: ruzickap/action-my-broken-link-checker@v2
+        with:
+          url: https://garethgeorge.github.io/backrest/
+          cmd_params: '-v --max-connections=3 --timeout=20 --buffer-size=8192 --color=always --exclude="(/_nuxt/|discord.com)"'
+
   deploy:
     needs: build
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,16 +34,17 @@ jobs:
             echo "::warning title=Invalid file permissions automatically fixed::$line"
           done
 
-      - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v2
-        with:
-          path: ./docs/.output/public
-
       - name: Check for broken links
         uses: ruzickap/action-my-broken-link-checker@v2
         with:
           url: https://garethgeorge.github.io/backrest/
+          pages_path: ./docs/.output/public
           cmd_params: '-v --max-connections=3 --timeout=20 --buffer-size=8192 --color=always --exclude="(/_nuxt/|discord.com)"'
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v2
+        with:
+          path: ./docs/.output/public
 
   deploy:
     needs: build


### PR DESCRIPTION
This should add a broken link detection step to the docs deployment workflow.  In the background, it's really using [Muffet](https://github.com/raviqqe/muffet) and doing this:
```
muffet -v --max-connections=3 --timeout=20 --buffer-size=8192 --color=always --exclude="(/_nuxt/|discord.com)" https://garethgeorge.github.io/backrest/
```

**Why add this?**
Doc sites are always important to the end user and the devs.  Broken links help no one and can happen out-of-the-blue.  Checking all links during the build would be beneficial as we could fix broken links before users notice them.

**Notes**
* Later on down the road, we may want to have this check be a separate GH Action that runs nightly.
* In this workflow, we're deploying the pages first and then scanning the public endpoint for broken links.  This was done so that the latest docs still get published even if there is a broken link.  We can re-order this later on, if wanted. It also has the ability to scan the local files instead so it can detect any errors _before_ publishing the pages.