### PR TITLE
docs: fix typo in command hook cookbook 

### DIFF
--- a/docs/content/3.cookbooks/1.command-hook-examples.md
+++ b/docs/content/3.cookbooks/1.command-hook-examples.md
@@ -6,7 +6,7 @@ Command hooks are a powerful way to extend Backrest's capabilities. They allow y
 
 ## Command Hook Options
 
-When run on `CONDITION_SNAPSHOT_START` command hooks have the ability to send contorl signals to Backrest based on the exit status of the script. The handling of the exit status is configured by the `Error Behavior` field. The following options are available:
+When run on `CONDITION_SNAPSHOT_START` command hooks have the ability to send control signals to Backrest based on the exit status of the script. The handling of the exit status is configured by the `Error Behavior` field. The following options are available:
 
 - `ON_ERROR_CANCEL` - If the script exits with a non-zero status, the backup operation will be canceled.
 - `ON_ERROR_FATAL` - If the script exits with a non-zero status, it is treated as a backup failure and error notifications are triggered.


### PR DESCRIPTION
Fix typo of "contorl" to "control"