### PR TITLE
fix: add condition_snapshot_success to .EventName

### DIFF
--- a/internal/orchestrator/tasks/hookvars.go
+++ b/internal/orchestrator/tasks/hookvars.go
@@ -39,6 +39,8 @@ func (v HookVars) EventName(cond v1.Hook_Condition) string {
 		return "snapshot error"
 	case v1.Hook_CONDITION_SNAPSHOT_WARNING:
 		return "snapshot warning"
+	case v1.Hook_CONDITION_SNAPSHOT_SUCCESS:
+		return "snapshot success"
 	case v1.Hook_CONDITION_CHECK_START:
 		return "check start"
 	case v1.Hook_CONDITION_CHECK_ERROR:


### PR DESCRIPTION
Hi,
I noticed that in hooks .EventName with SNAPSHOT_SUCCESS was reported as unkown
It is a little fix

P.S.: Just noticed it closes #390