### PR TITLE
Add image source label to dockerfiles

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,4 +1,5 @@
 FROM alpine:latest
+LABEL org.opencontainers.image.source="https://github.com/garethgeorge/backrest"
 RUN apk --no-cache add tini ca-certificates curl bash rclone openssh tzdata docker-cli
 RUN mkdir -p /tmp
 COPY backrest /backrest

--- a/Dockerfile.scratch
+++ b/Dockerfile.scratch
@@ -5,7 +5,8 @@ COPY backrest /backrest
 RUN /backrest --install-deps-only
 RUN mkdir -p /bin && mv /root/.local/share/backrest/* /bin
 
-FROM scratch 
+FROM scratch
+LABEL org.opencontainers.image.source="https://github.com/garethgeorge/backrest"
 COPY --from=alpine /tmp-orig /tmp
 COPY --from=alpine /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=alpine /bin /bin


### PR DESCRIPTION
To get changelogs shown with Renovate a docker container has to add the source label described in the OCI Image Format Specification.

For reference: https://github.com/renovatebot/renovate/blob/main/lib/modules/datasource/docker/readme.md