### PR TITLE
fix: garbage collection with more sensible limits grouped by plan/repo

### DIFF
--- a/internal/orchestrator/tasks/taskcollectgarbage.go
+++ b/internal/orchestrator/tasks/taskcollectgarbage.go
@@ -174,8 +174,6 @@ func (t *CollectGarbageTask) gcOperations(log *oplog.OpLog) error {
 		return fmt.Errorf("identifying gc eligible operations: %w", err)
 	}
 
-	zap.L().Debug("gc operation IDs", zap.Any("ids", forgetIDs))
-
 	if err := log.Delete(forgetIDs...); err != nil {
 		return fmt.Errorf("removing gc eligible operations: %w", err)
 	}


### PR DESCRIPTION
Garbage collection now enforces limits that better guarantee correctness w.r.t. new scheduling features (e.g. last run relative scheduling) and that make more sense in the UI.

For each repo 

 * Prune and Check operations retain the last 12 executions. More than this should not be necessary. They are retained for a maximum time of 12 months.
 * Stats operations are retained for up to 1 year OR 100 data points to preserve preformance.
 * All other operations are retained up to 30 days or 100 operations.

Note that "snapshot" association overrides these rules e.g. if an operation is associated with a snapshot that is still present in the repo, the operation will not be deleted until that snapshot is forgotten.