### PR TITLE
fix: improve windows installer and relocate backrest on Windows to %localappdata%\programs 

### DIFF
--- a/build/windows/install.nsi
+++ b/build/windows/install.nsi
@@ -3,7 +3,7 @@
 !define APP_NAME "Backrest"
 !define COMP_NAME "garethgeorge"
 !define WEB_SITE "https://github.com/garethgeorge/backrest"
-!define VERSION "00.00.00.00"
+!define VERSION "1.6.1.0"
 !define COPYRIGHT "garethgeorge   2024"
 !define DESCRIPTION "Application"
 !define LICENSE_TXT "${BUILD_DIR}\LICENSE"
@@ -29,6 +29,7 @@ VIAddVersionKey "FileVersion"  "${VERSION}"
 
 ######################################################################
 
+RequestExecutionLevel user
 SetCompressor ZLIB
 Name "${APP_NAME}"
 Caption "${APP_NAME}"
@@ -36,7 +37,8 @@ OutFile "${INSTALLER_NAME}"
 BrandingText "${APP_NAME}"
 XPStyle on
 InstallDirRegKey "${REG_ROOT}" "${REG_APP_PATH}" ""
-InstallDir "$PROGRAMFILES64\Backrest"
+InstallDir "$LOCALAPPDATA\Programs\Backrest"
+ManifestDPIAware true
 
 ######################################################################
 
@@ -83,13 +85,14 @@ SetOutPath "$INSTDIR"
 File "${BUILD_DIR}\backrest.exe"
 File "${BUILD_DIR}\backrest-windows-tray.exe"
 File "${BUILD_DIR}\LICENSE"
+File "${BUILD_DIR}\icon.ico"
 SectionEnd
 
 ######################################################################
 
 Section "Run at startup"
 CreateDirectory $SMSTARTUP
-CreateShortcut "$SMSTARTUP\$(^Name).lnk" "$INSTDIR\${MAIN_APP_EXE}" "" "${BUILD_DIR}\icon.ico" 0
+CreateShortcut "$SMSTARTUP\$(^Name).lnk" "$INSTDIR\${MAIN_APP_EXE}" "" "$INSTDIR\icon.ico" 0
 SectionEnd
 
 Section -Icons_Reg
@@ -99,34 +102,34 @@ WriteUninstaller "$INSTDIR\uninstall.exe"
 !ifdef REG_START_MENU
 !insertmacro MUI_STARTMENU_WRITE_BEGIN Application
 CreateDirectory "$SMPROGRAMS\$SM_Folder"
-CreateShortCut "$SMPROGRAMS\$SM_Folder\${APP_NAME}.lnk" "$INSTDIR\${MAIN_APP_EXE}" "" "${BUILD_DIR}\icon.ico" 0
-CreateShortCut "$DESKTOP\${APP_NAME} Console.lnk" "$INSTDIR\${MAIN_APP_EXE}" "" "${BUILD_DIR}\icon.ico" 0
-CreateShortCut "$DESKTOP\${APP_NAME} UI.lnk" "http://localhost:9898/" "" "${BUILD_DIR}\icon.ico" 0
-CreateShortCut "$SMPROGRAMS\$SM_Folder\Uninstall ${APP_NAME}.lnk" "$INSTDIR\uninstall.exe" "" "${BUILD_DIR}\icon.ico" 0
+CreateShortCut "$SMPROGRAMS\$SM_Folder\${APP_NAME}.lnk" "$INSTDIR\${MAIN_APP_EXE}" "" "$INSTDIR\icon.ico" 0
+CreateShortCut "$DESKTOP\${APP_NAME}.lnk" "$INSTDIR\${MAIN_APP_EXE}" "" "$INSTDIR\icon.ico" 0
+CreateShortCut "$DESKTOP\${APP_NAME} UI.lnk" "http://localhost:9898/" "" "$INSTDIR\icon.ico" 0
+CreateShortCut "$SMPROGRAMS\$SM_Folder\Uninstall ${APP_NAME}.lnk" "$INSTDIR\uninstall.exe" "" "$INSTDIR\icon.ico" 0
 
 !ifdef WEB_SITE
 WriteIniStr "$INSTDIR\${APP_NAME} website.url" "InternetShortcut" "URL" "${WEB_SITE}"
-CreateShortCut "$SMPROGRAMS\$SM_Folder\${APP_NAME} Website.lnk" "$INSTDIR\${APP_NAME} website.url" "" "${BUILD_DIR}\icon.ico" 0
+CreateShortCut "$SMPROGRAMS\$SM_Folder\${APP_NAME} Website.lnk" "$INSTDIR\${APP_NAME} website.url" "" "$INSTDIR\icon.ico" 0
 !endif
 !insertmacro MUI_STARTMENU_WRITE_END
 !endif
 
 !ifndef REG_START_MENU
 CreateDirectory "$SMPROGRAMS\Backrest"
-CreateShortCut "$SMPROGRAMS\Backrest\${APP_NAME}.lnk" "$INSTDIR\${MAIN_APP_EXE}" "" "${BUILD_DIR}\icon.ico" 0
-CreateShortCut "$DESKTOP\${APP_NAME}.lnk" "$INSTDIR\${MAIN_APP_EXE}" "" "${BUILD_DIR}\icon.ico" 0
-CreateShortCut "$SMPROGRAMS\Backrest\Uninstall ${APP_NAME}.lnk" "$INSTDIR\uninstall.exe" "" "${BUILD_DIR}\icon.ico" 0
+CreateShortCut "$SMPROGRAMS\Backrest\${APP_NAME}.lnk" "$INSTDIR\${MAIN_APP_EXE}" "" "${INSTDIR}\icon.ico" 0
+CreateShortCut "$DESKTOP\${APP_NAME}.lnk" "$INSTDIR\${MAIN_APP_EXE}" "" "${INSTDIR}\icon.ico" 0
+CreateShortCut "$SMPROGRAMS\Backrest\Uninstall ${APP_NAME}.lnk" "$INSTDIR\uninstall.exe" "" "${INSTDIR}\icon.ico" 0
 
 !ifdef WEB_SITE
 WriteIniStr "$INSTDIR\${APP_NAME} website.url" "InternetShortcut" "URL" "${WEB_SITE}"
-CreateShortCut "$SMPROGRAMS\Backrest\${APP_NAME} Website.lnk" "$INSTDIR\${APP_NAME} website.url" "" "${BUILD_DIR}\icon.ico" 0
+CreateShortCut "$SMPROGRAMS\Backrest\${APP_NAME} Website.lnk" "$INSTDIR\${APP_NAME} website.url" "" "${INSTDIR}\icon.ico" 0
 !endif
 !endif
 
 WriteRegStr ${REG_ROOT} "${REG_APP_PATH}" "" "$INSTDIR\${MAIN_APP_EXE}"
 WriteRegStr ${REG_ROOT} "${UNINSTALL_PATH}"  "DisplayName" "${APP_NAME}"
 WriteRegStr ${REG_ROOT} "${UNINSTALL_PATH}"  "UninstallString" "$INSTDIR\uninstall.exe"
-WriteRegStr ${REG_ROOT} "${UNINSTALL_PATH}"  "DisplayIcon" "$INSTDIR\${MAIN_APP_EXE}"
+WriteRegStr ${REG_ROOT} "${UNINSTALL_PATH}"  "DisplayIcon" "$INSTDIR\icon.ico"
 WriteRegStr ${REG_ROOT} "${UNINSTALL_PATH}"  "DisplayVersion" "${VERSION}"
 WriteRegStr ${REG_ROOT} "${UNINSTALL_PATH}"  "Publisher" "${COMP_NAME}"
 
@@ -139,9 +142,14 @@ SectionEnd
 
 Section Uninstall
 ${INSTALL_TYPE}
+ExecWait "TASKKILL /IM backrest-windows-tray.exe"
+Sleep 1000
+Delete "$INSTDIR\LICENSE"
+Delete "$INSTDIR\icon.ico"
+Delete "$INSTDIR\install.lock"
+Delete "$INSTDIR\restic*.exe"
 Delete "$INSTDIR\backrest.exe"
 Delete "$INSTDIR\backrest-windows-tray.exe"
-Delete "$INSTDIR\LICENSE"
 Delete "$INSTDIR\uninstall.exe"
 Delete "$SMSTARTUP\$(^Name).lnk"
 !ifdef WEB_SITE
@@ -154,10 +162,13 @@ RmDir "$INSTDIR"
 !insertmacro MUI_STARTMENU_GETFOLDER "Application" $SM_Folder
 Delete "$SMPROGRAMS\$SM_Folder\${APP_NAME}.lnk"
 Delete "$SMPROGRAMS\$SM_Folder\Uninstall ${APP_NAME}.lnk"
+Delete "$DESKTOP\${APP_NAME}.lnk"
+Delete "$DESKTOP\${APP_NAME} UI.lnk"
 !ifdef WEB_SITE
 Delete "$SMPROGRAMS\$SM_Folder\${APP_NAME} Website.lnk"
 !endif
 Delete "$DESKTOP\${APP_NAME}.lnk"
+
 
 RmDir "$SMPROGRAMS\$SM_Folder"
 !endif


### PR DESCRIPTION
Various fixes before decisions are made regarding multi-purpose installer (https://github.com/garethgeorge/backrest/issues/549)

1. Changed installation location to user %localappdata%\programs since the installer already installed all icons and made registry entry only for the current user.
2. Fixed blurry installer text on high DPI screens.
3. Fixed icon for Start Menu, Desktop shortcuts, and Add/Remove programs entry.
4. Fixed uninstaller not terminating running application and not fully cleaning up installed files.

Users upgrading from the previous installer should uninstall it first to avoid conflicts. User configuration will stay intact.