### PR TITLE
Clarify notes about the port for Windows installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,8 +227,8 @@ Download a the Windows installer for your architecture from the [releases page](
 
 The installer will place backrest and a GUI tray application to monitor backrest in `%localappdata%\Programs\Backrest\`. The GUI tray application will start on login by default. 
 
-> [!NOTE] You can optionally override the default port of the installation by using PowerShell to run the installer with the `BACKREST_PORT` environment variable set to the desired port. E.g. to run backrest on port 8080, run the following command in PowerShell: `BACKREST_PORT=:8080 .\Backrest-setup-x86_64.exe`
-
+> [!NOTE] You can optionally override the default port Backrest uses by adding a user environment variable before running the installer. Open System Properties. There are multiple ways of getting there depending on Windows version. On Windows 10+ go to Settings - About - Advanced system settings (on the right side). At the bottom of the dialog window click Environment Variables. In the top section called "User variables for...", click New. Enter BACKREST_PORT as the variable name. Enter 127.0.0.1:port as the variable value. E.g. to run backrest on port 8080, enter 127.0.0.1:8080.
+If you make this change after Backrest is installed, just re-run the installer to update shortcuts with the new port.
 
 # Configuration
 


### PR DESCRIPTION
Apologies if I caused confusion around the port behaviour. Running the installer as you described with PowerShell would have the installer pick up the session variable and use the port for UI shortcuts, but Backrest itself would still listen on the default port upon the next reboot.
Also, using : instead of 127.0.0.1: would cause Backrest to listen on all interfaces, thus exposing it to outside access.

The correct way to define a user variable persistently is described in this commit. I also made changes to the installer, including the language around the port. If Backrest supported port definition through a command-line switch (like --port=), then I could add an option to the installer to take user input and create the startup shortcut with the switch. The switch would have to be available in the backrest-windows-tray.exe since this is what starts the software. Not saying it is needed, just explaining what would have to be done to avoid the environment variable steps I described. Unfortunately, Windows doesn't support passing session variables through shortcuts, unless using cmd wrapper script, which is a bit ugly.

Custom port is probably an advanced feature not needed by most users. I think what we have now is very reasonable.