### PR TITLE
fix: avoid ant design url rule as it requires a tld to be present

### DIFF
--- a/webui/src/components/HooksFormList.tsx
+++ b/webui/src/components/HooksFormList.tsx
@@ -247,7 +247,7 @@ const hookTypes: {
         <>
           <Form.Item
             name={[field.name, "actionDiscord", "webhookUrl"]}
-            rules={[requiredField("webhook URL is required"), { type: "url" }]}
+            rules={[requiredField("webhook URL is required")]}
           >
             <Input
               addonBefore={<div style={{ width: "8em" }}>Discord Webhook</div>}
@@ -331,7 +331,7 @@ const hookTypes: {
         <>
           <Form.Item
             name={[field.name, "actionSlack", "webhookUrl"]}
-            rules={[requiredField("webhook URL is required"), { type: "url" }]}
+            rules={[requiredField("webhook URL is required")]}
           >
             <Input
               addonBefore={<div style={{ width: "8em" }}>Slack Webhook</div>}
@@ -362,7 +362,7 @@ const hookTypes: {
         <>
           <Form.Item
             name={[field.name, "actionHealthchecks", "webhookUrl"]}
-            rules={[requiredField("Ping URL is required"), { type: "url" }]}
+            rules={[requiredField("Ping URL is required")]}
           >
             <Input addonBefore={<div style={{ width: "8em" }}>Ping URL</div>} />
           </Form.Item>


### PR DESCRIPTION
fixes: #612 

The Ant Design System Form.Item rules has behavior (bug?) where it requires a TLD to be preset in order for a URL to be valid, which is undesirable for Healthchecks as it allows self hosting an instance, and using a URL like `http://healthchecks:8080` is a valid URL 

I went ahead and removed the rule from both Slack and Discord for consistency, however the TLD check there is less problematic as these are SASS services. I am happy to restore those if it is preferred to continue to have the rule applied to these hooks.  