### PR TITLE
fix: local network access on macOS 15 Sequoia

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -31,7 +31,7 @@ builds:
       - amd64
       - arm64
     ldflags:
-      - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}}
+      - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}} -B gobuildid
   - id: linux
     main: ./cmd/backrest
     env:


### PR DESCRIPTION
# Background
An issue has been identified where Go binaries running on macOS 15 (Sequoia) fail to access local network devices (like rest-server repos) when the binary lacks a LC_UUID load command. This affects backrest when running as a service through Homebrew, while direct Terminal execution works due to inherited permissions.

# Technical Details
- Issue tracked in golang/go#68678
- Affects binaries missing LC_UUID (verifiable via `dwarfdump --uuid backrest`)
- Connected to issue #494
- Will be fixed by default in Go 1.24, but requires manual flag for Go 1.23

# Solution
This PR implements the workaround for Go 1.23 by adding the following linker flag to the release pipeline: `
-ldflags="-B gobuildid"`

# Validation
Local testing with the modified build flag confirms:
- UUID is properly generated in the binary
 - Successfully connects to rest-server repositories
- Functions correctly when run as a Homebrew service

# Related Issues
- Fixes #494
- References golang/go#68678

# Notes
This change is temporary and can be removed once we migrate to Go 1.24, where UUID generation will be enabled by default.
