### PR TITLE
chore: update devcontainer image

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
       // Update the VARIANT arg to pick a version of Go: 1, 1.16, 1.17
       // Append -bullseye or -buster to pin to an OS version.
       // Use -bullseye variants on local arm64/Apple Silicon.
-      "VARIANT": "1-1.21-bookworm",
+      "VARIANT": "1-1.23-bookworm",
       // Options
       "NODE_VERSION": "lts/*"
     }


### PR DESCRIPTION
This pull request includes an update to the `.devcontainer/devcontainer.json` file. The change updates the Go version used in the development container configuration. Go 1.23 is needed for some of the dependencies used by this project.

* [`.devcontainer/devcontainer.json`](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L9-R9): Updated the `VARIANT` argument from `1-1.21-bookworm` to `1-1.23-bookworm` to use a newer version of Go.