### PR TITLE
chore: update Go version and remove workaround

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -31,7 +31,7 @@ builds:
       - amd64
       - arm64
     ldflags:
-      - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}} -B gobuildid
+      - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}}
   - id: linux
     main: ./cmd/backrest
     env:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/garethgeorge/backrest
 
-go 1.23.1
+go 1.24
 
 replace (
 	modernc.org/libc => modernc.org/libc v1.55.3


### PR DESCRIPTION
# Background
In PR https://github.com/garethgeorge/backrest/pull/630 a build flag was introduced to generate a LC_UUID for binaries fixing an issue with local network communication on MacOS 15. With Go 1.24 this build flag is not necessary anymore.

# Technical details
- Old PR: https://github.com/garethgeorge/backrest/pull/630, refer to its "Note"
- Go 1.24 changelog on that issue: https://tip.golang.org/doc/go1.24#linker

# Solution
Upgrade Go version and remove deprecated flag.

# Validation
Local build of Backrest now contains UUID without needing the flag.