### PR TITLE
Add gzip to Alpine Docker Container

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,6 +1,6 @@
 FROM alpine:latest
 LABEL org.opencontainers.image.source="https://github.com/garethgeorge/backrest"
-RUN apk --no-cache add tini ca-certificates curl bash rclone openssh tzdata docker-cli
+RUN apk --no-cache add tini ca-certificates curl bash rclone openssh tzdata docker-cli gzip
 RUN mkdir -p /tmp
 COPY backrest /backrest
 RUN /backrest --install-deps-only


### PR DESCRIPTION
I'm using gzip to compress my database dumps and wanted to use the --rsyncable argument. Unfortunately, the included BusyBox version of gzip does not include this argument.
It would be great if the latest standalone version of gzip could be included by default.