### PR TITLE
Update hook documentation for snapshot start for better details

### DIFF
--- a/docs/content/2.docs/2.hooks.md
+++ b/docs/content/2.docs/2.hooks.md
@@ -7,7 +7,7 @@ Hooks in Backrest allow you to respond to various operation lifecycle events, en
 Hooks can be triggered by the following events:
 
 ### Snapshot Events
-- `CONDITION_SNAPSHOT_START`: Triggered when a backup operation begins
+- `CONDITION_SNAPSHOT_START`: Triggered when a backup operation begins and will complete before the snapshot starts. The [Error Handling](#error-handling) configuration can be used to stop the backup if the command isnt successful.
 - `CONDITION_SNAPSHOT_END`: Triggered when a backup operation completes (regardless of success/failure)
 - `CONDITION_SNAPSHOT_SUCCESS`: Triggered when a backup operation completes successfully
 - `CONDITION_SNAPSHOT_ERROR`: Triggered when a backup operation fails


### PR DESCRIPTION
Add details on how the snapshot start can be used to trigger other backups

I am using this to trigger a DB backup before a snapshot it  taken and wanted to be clear that it completed before the snapshot ran. I manually tested to validate that is the case, but i figured this should be something mentioned in the docs.

I was considering adding some additional docs with an example of how to leverage this.

In my case i ended up mounting the docker sock, and used the command `docker exec -t vaultwarden /vaultwarden backup` to trigger a db backup before the snapshot.

Happy to do another PR with an example like this if you think it makes sense.

Thanks!