### PR TITLE
chore: contributor tooling fixes

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
       // Update the VARIANT arg to pick a version of Go: 1, 1.16, 1.17
       // Append -bullseye or -buster to pin to an OS version.
       // Use -bullseye variants on local arm64/Apple Silicon.
-      "VARIANT": "1-1.23-bookworm",
+      "VARIANT": "1-1.24-bookworm",
       // Options
       "NODE_VERSION": "lts/*"
     }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.23"
+          go-version: "1.24"
 
       - name: Setup NodeJS
         uses: actions/setup-node@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.23"
+          go-version: "1.24"
 
       - name: Setup NodeJS
         uses: actions/setup-node@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.23"
+          go-version: "1.24"
 
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@latest
@@ -49,7 +49,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.23"
+          go-version: "1.24"
 
       - name: Create Fake WebUI Sources
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ cmd/backrest/backrest
 *.exe
 .DS_Store
 .idea/
+.pnpm-store/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,7 @@
       "type": "go",
       "request": "launch",
       "mode": "debug",
-      "program": "${workspaceFolder}/backrest.go",
+      "program": "${workspaceFolder}/cmd/backrest/backrest.go",
       "output": "__debug_bin",
       "preLaunchTask": "Build Webui"
     },

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,7 +4,7 @@
     {
       "label": "npm i",
       "type": "shell",
-      "command": "cd webui && npm i"
+      "command": "cd webui && npx --yes pnpm i"
     },
     {
       "label": "Parcel",


### PR DESCRIPTION
This addresses some problems that I had trying to get backrest running with VS Code Dev Containers:
* Some npm dependencies were causing issues, regrettably I don't have logs to share details but since you have a lockfile available I am doing the install with `pnpm` (via `npx`) instead of `npm`
* The backrest.go file had moved
* The dev container was not building the backend since it still used go 1.23
* In a search for all 1.23 I updated the github workflows to go 1.24 as well, can remove those edits if not desireable

It may also be helpful to note somewhere the most recently used versions for go packages since mismatched versions make for excess changes (particularly since the generated files all include the version number of the generator). For my other pull request I rolled back two of the dependencies from latest to avoid unnecessary edits:
```
npm i @bufbuild/protoc-gen-es@2.2.2 -g
go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.35.2
```

There were still a few files generated differently but I just ignored them since they were unrelated to my PR and did not have a version number commented in the generated file.