### PR TITLE
[Docker] Add docker-cli-ompose to the base image of the container

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,6 +1,6 @@
 FROM alpine:latest
 LABEL org.opencontainers.image.source="https://github.com/garethgeorge/backrest"
-RUN apk --no-cache add tini ca-certificates curl bash rclone openssh tzdata docker-cli
+RUN apk --no-cache add tini ca-certificates curl bash rclone openssh tzdata docker-cli docker-cli-compose
 RUN mkdir -p /tmp
 COPY backrest /backrest
 RUN /backrest --install-deps-only


### PR DESCRIPTION
Proposal to add docker-cli-compose to the packages the backrest docker image ships by default.

I think it is useful to have access to the docker compose commands in hooks to stop and start whole stacks from backrest.
