### PR TITLE
Fix ToolTipIcon Info Enum

### DIFF
--- a/docs/content/3.cookbooks/1.command-hook-examples.md
+++ b/docs/content/3.cookbooks/1.command-hook-examples.md
@@ -175,7 +175,7 @@ Display temporary success notifications.
 Add-Type -AssemblyName System.Windows.Forms
 $balloon = New-Object System.Windows.Forms.NotifyIcon
 $balloon.Icon = [System.Drawing.SystemIcons]::Information
-$balloon.BalloonTipIcon = [System.Windows.Forms.ToolTipIcon]::Information
+$balloon.BalloonTipIcon = [System.Windows.Forms.ToolTipIcon]::Info
 $balloon.BalloonTipText = '{{ .Summary }}'
 $balloon.BalloonTipTitle = "Backrest"
 $balloon.Visible = $true


### PR DESCRIPTION
The [ToolTipIcon](https://learn.microsoft.com/en-us/dotnet/api/system.windows.forms.tooltipicon) information enum is "Info" rather than "Information"