### PR TITLE
fix: use 'restic mount' for fast repo browsing when available

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,12 @@ services:
     ports:
       - "9898:9898"
     restart: unless-stopped
+    # Optional, these are required for fast repo browsing mode using FUSE
+    # but are not required for the default repo browsing mode using `restic ls`
+    cap_add:
+      - SYS_ADMIN
+    devices:
+      - /dev/fuse:/dev/fuse
 ```
 
 ## Running on Linux

--- a/internal/orchestrator/repo/repo.go
+++ b/internal/orchestrator/repo/repo.go
@@ -114,7 +114,7 @@ func (r *RepoOrchestrator) Mount(ctx context.Context) (string, func(), error) {
 			return "", func() {}, r.mountErr
 		}
 
-		mountCtx, cancel := context.WithCancel(ctx)
+		mountCtx, cancel := context.WithCancel(context.Background())
 		if err := r.repo.Mount(mountCtx, r.mountDir, 60*time.Second); err != nil {
 			r.logger(ctx).Warn("failed to mount repo", zap.Error(err))
 			r.mountErr = fmt.Errorf("mount repo %v: %w", r.repoConfig.Id, err)

--- a/internal/orchestrator/repo/repo.go
+++ b/internal/orchestrator/repo/repo.go
@@ -114,21 +114,14 @@ func (r *RepoOrchestrator) Mount(ctx context.Context) (string, func(), error) {
 			return "", func() {}, r.mountErr
 		}
 
-		// Give mount 60 seconds to succeed, but if it succeeds allow it to run indefinitely in the background.
-		mountCtx, cancel := context.WithCancel(context.Background())
-		cancelMounting := time.AfterFunc(60*time.Second, func() {
-			cancel()
-		})
-
-		if err := r.repo.Mount(mountCtx, r.mountDir); err != nil {
+		mountCtx, cancel := context.WithCancel(ctx)
+		if err := r.repo.Mount(mountCtx, r.mountDir, 60*time.Second); err != nil {
 			r.logger(ctx).Warn("failed to mount repo", zap.Error(err))
 			r.mountErr = fmt.Errorf("mount repo %v: %w", r.repoConfig.Id, err)
 			cancel()
-			cancelMounting.Stop()
 			os.Remove(r.mountDir)
 			return "", func() {}, r.mountErr
 		}
-		cancelMounting.Stop()
 		r.mountTimer = time.AfterFunc(1000*time.Hour, func() {
 			r.mountMu.Lock()
 			defer r.mountMu.Unlock()


### PR DESCRIPTION
Marked as a 'fix' predominantly to include with the next minor version release.

This introduces support for `restic mount`. The mount command is allowed to return while running in a background thread as soon as the mount is detected to be serving snapshots (based on a spin wait).

Backrest keeps mounts alive in the background for 60 seconds before terminating them and will spin them up again as needed.