### PR TITLE
Improve logo visibility in dark mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
-<p align="center"><img src="./webui/assets/logo-black.svg" width="400px"/></p>
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="./webui/assets/logo.svg" width="400px">
+    <source media="(prefers-color-scheme: light)" srcset="./webui/assets/logo-black.svg" width="400px">
+    <img src="./webui/assets/logo.svg" width="400px">
+  </picture>
+</p>
 
 <p align="center">
   <img src="https://github.com/garethgeorge/backrest/actions/workflows/test.yml/badge.svg" />


### PR DESCRIPTION
Hi,

the backrest logo is barely visible on GitHub in dark mode, so I adjusted the README to show the logo based on the browser theme.

Updated logo display in README for dark and light themes.