### PR TITLE
fix: Avoid shared cache memory databases

### DIFF
--- a/internal/api/syncapi/peerstate_test.go
+++ b/internal/api/syncapi/peerstate_test.go
@@ -5,9 +5,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/garethgeorge/backrest/internal/cryptoutil"
 	"github.com/google/go-cmp/cmp"
 	_ "github.com/ncruces/go-sqlite3/driver"
+	"github.com/ncruces/go-sqlite3/vfs/memdb"
 )
 
 func PeerStateManagersForTest(t testing.TB) map[string]PeerStateManager {
@@ -92,7 +92,7 @@ func TestPeerStateManager_OnStateChanged(t *testing.T) {
 
 func newDbForTest(t testing.TB) *sql.DB {
 	t.Helper()
-	dbpool, err := sql.Open("sqlite3", "file:"+cryptoutil.MustRandomID(64)+"?mode=memory&cache=shared")
+	dbpool, err := sql.Open("sqlite3", memdb.TestDB(t))
 	if err != nil {
 		t.Fatalf("error creating sqlite pool: %s", err)
 	}

--- a/internal/api/syncapi/syncapi_test.go
+++ b/internal/api/syncapi/syncapi_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/garethgeorge/backrest/internal/resticinstaller"
 	"github.com/garethgeorge/backrest/internal/testutil"
 	"github.com/google/go-cmp/cmp"
+	"github.com/ncruces/go-sqlite3/vfs/memdb"
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/h2c"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -748,7 +749,7 @@ func newPeerUnderTest(t *testing.T, initialConfig *v1.Config) *peerUnderTest {
 		wg.Done()
 	}()
 
-	dbpool, err := sql.Open("sqlite3", "file:"+cryptoutil.MustRandomID(64)+"?mode=memory&cache=shared")
+	dbpool, err := sql.Open("sqlite3", memdb.TestDB(t))
 	if err != nil {
 		t.Fatalf("failed to open sqlite pool: %v", err)
 	}

--- a/internal/kvstore/sqlitekvstore_test.go
+++ b/internal/kvstore/sqlitekvstore_test.go
@@ -8,18 +8,15 @@ import (
 	"testing"
 
 	_ "github.com/ncruces/go-sqlite3/driver"
+	"github.com/ncruces/go-sqlite3/vfs/memdb"
 )
 
 func newTestDB(t testing.TB) *sql.DB {
-	db, err := sql.Open("sqlite3", "file::memory:?cache=shared")
+	t.Helper()
+	db, err := sql.Open("sqlite3", memdb.TestDB(t))
 	if err != nil {
 		t.Fatalf("failed to open memory database: %v", err)
 	}
-	t.Cleanup(func() {
-		if err := db.Close(); err != nil {
-			t.Logf("failed to close db: %v", err)
-		}
-	})
 	return db
 }
 


### PR DESCRIPTION
My driver does not support [shared cache](https://github.com/ncruces/go-sqlite3/discussions/97), so you'll eventually bump into this issue: https://github.com/ncruces/go-sqlite3/discussions/188

The preferred pattern for tests is to use [`memdb.TestDB`](https://pkg.go.dev/github.com/ncruces/go-sqlite3/vfs/memdb#TestDB); this handles test cleanup as well.