### PR TITLE
Feat: adds the installation of an openrc service script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -98,7 +98,8 @@ depend() {
 
 command=/usr/local/bin/backrest
 command_background=true
-pidfile="/run/${RC_SVCNAME}.pid"
+pidfile="/run/\${RC_SVCNAME}.pid"
+command_user="$(whoami):$(whoami)"
 
 export BACKREST_PORT=$BACKREST_PORT
 EOM


### PR DESCRIPTION
This is my own implementation, responding to the Issue #946 (Add openrc support) which I myself opened.

I'd like to point out again that I did change the systemd (now systemd/openrc) detection method.
