### PR TITLE
Use default locale for formatting dates

### DIFF
--- a/webui/src/lib/formatting.ts
+++ b/webui/src/lib/formatting.ts
@@ -47,7 +47,7 @@ export const localISOTime = (time: number | string | Date) => {
   return d.toISOString();
 };
 
-const fmtDate = new Intl.DateTimeFormat({
+const fmtDate = new Intl.DateTimeFormat(undefined, {
   year: "numeric",
   month: "2-digit",
   day: "2-digit",


### PR DESCRIPTION
Removed hard-coded locale from `Intl.DateTimeFormat`. Ensures that dates are formatted in the users locale.

It's not entirely clear to my why `US` was picked so I could be missing something!