### PR TITLE
fix: getOperationEvents use create EmptySchema not javascript empty object

### DIFF
--- a/webui/src/state/oplog.ts
+++ b/webui/src/state/oplog.ts
@@ -6,6 +6,8 @@ import {
 } from "../../gen/ts/v1/operations_pb";
 import { GetOperationsRequest, OpSelector } from "../../gen/ts/v1/service_pb";
 import { BackupProgressEntry, ResticSnapshot, RestoreProgressEntry } from "../../gen/ts/v1/restic_pb";
+import { EmptySchema } from "../../gen/ts/types/value_pb";
+import { create } from "@bufbuild/protobuf";
 import _ from "lodash";
 import { backrestService } from "../api";
 
@@ -16,7 +18,7 @@ const subscribers: ((event?: OperationEvent, err?: Error) => void)[] = [];
   while (true) {
     let nextConnWaitUntil = new Date().getTime() + 5000;
     try {
-      for await (const event of backrestService.getOperationEvents({})) {
+      for await (const event of backrestService.getOperationEvents(create(EmptySchema, {}))) {
         console.log("operation event", event);
         subscribers.forEach((subscriber) => subscriber(event, undefined));
       }

--- a/webui/src/views/SummaryDashboard.tsx
+++ b/webui/src/views/SummaryDashboard.tsx
@@ -17,6 +17,8 @@ import {
   SummaryDashboardResponse,
   SummaryDashboardResponse_Summary,
 } from "../../gen/ts/v1/service_pb";
+import { EmptySchema } from "../../gen/ts/types/value_pb";
+import { create } from "@bufbuild/protobuf";
 import { backrestService } from "../api";
 import { useAlertApi } from "../components/Alerts";
 import {
@@ -65,7 +67,7 @@ export const SummaryDashboard = () => {
       }
 
       try {
-        const data = await backrestService.getSummaryDashboard({});
+        const data = await backrestService.getSummaryDashboard(create(EmptySchema, {}));
         setSummaryData(data);
       } catch (e) {
         alertApi.error("Failed to fetch summary data: " + e);


### PR DESCRIPTION
backrestService.getOperationEvents parameters change to use create(EmptySchema)  to avoid the request's body from webui have 5 NULL content and calls the backend  504 Timeout, 
<img width="568" height="221" alt="image" src="https://github.com/user-attachments/assets/82048093-6a7d-42f5-bf59-c6158fb081e8" />
