### PR TITLE
Add podman to Alpine image

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -6,7 +6,7 @@ RUN go build -o /docker-entrypoint -ldflags "-s -w" ./cmd/docker-entrypoint
 
 FROM alpine:latest
 LABEL org.opencontainers.image.source="https://github.com/garethgeorge/backrest"
-RUN apk --no-cache add tini ca-certificates curl bash rclone openssh tzdata docker-cli
+RUN apk --no-cache add tini ca-certificates curl bash rclone openssh tzdata docker-cli podman
 RUN mkdir -p /tmp
 COPY backrest /backrest
 RUN /backrest --install-deps-only


### PR DESCRIPTION
Useful to allow managing of container with podman before/after exporting volumes. Unfortunately does add a few MB to the image.