### PR TITLE
fix: overwrite service scripts - supervise openrc daemon

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -65,6 +65,7 @@ Type=simple
 User=$(whoami)
 Group=$(whoami)
 ExecStart=/usr/local/bin/backrest
+Restart=on-failure
 Environment="BACKREST_PORT=$BACKREST_PORT"
 
 [Install]


### PR DESCRIPTION
The two commits are kinda self-explanatory.
During my last pull request, I submitted a new install script. I just realised that my version did not start back the service after terminating it, in the case in which a service script/systemd unit was already installed.
Aside from my bug, also there is a point in updating the service scripts together with the software in case it is needed. The simplest case is the case in which the user forgets _--allow-remote-access_ and wants to reinstall with a different port binding. This fixes the problem.

As it can be read in https://github.com/garethgeorge/backrest/pull/947 it was the user @inode64 that suggested to add the supervised daemon line in the openrc script. I don't think this change is big enough to justify a pull request of its own, forgive me for including it here.