### PR TITLE
fix: FormatSizeBytes reports incorrect sizes with fractional-gigabytes.

### DIFF
--- a/internal/orchestrator/tasks/hookvars.go
+++ b/internal/orchestrator/tasks/hookvars.go
@@ -88,16 +88,14 @@ func (v HookVars) number(n any) int {
 }
 
 func (v HookVars) FormatSizeBytes(val any) string {
-	size := v.number(val)
+	size := float64(v.number(val))
 	sizes := []string{"B", "KB", "MB", "GB", "TB", "PB"}
 	i := 0
-	prev := size
 	for size > 1000 {
 		size /= 1000
-		prev = size
 		i++
 	}
-	return fmt.Sprintf("%d.%03d %s", size, prev, sizes[i])
+	return fmt.Sprintf("%.3f %s", size, sizes[i])
 }
 
 func (v HookVars) IsError(cond v1.Hook_Condition) bool {


### PR DESCRIPTION
I have noticed the size reporting in the .Summary template function being incorrect. The issue is the value on both sides of the decimal place is the same.

For example:

<img width="995" height="660" alt="image" src="https://github.com/user-attachments/assets/0b31f77e-f4e9-488d-989b-369126495771" />

Now.. I'm not yet sure if this change is how the formatting should be done either.