### PR TITLE
docs: update ssh-remote cookbook for rootless container setup

### DIFF
--- a/docs/content/3.cookbooks/4.ssh-remote.md
+++ b/docs/content/3.cookbooks/4.ssh-remote.md
@@ -94,6 +94,7 @@ services:
       - ./backrest/cache:/cache
       # ... other volumes ...
       - ./backrest/ssh:/root/.ssh:ro # Add this line
+      - ./backrest/ssh:/.ssh:ro # Add this line if running rootless
     # ... rest of configuration ...
 ```
 


### PR DESCRIPTION
Fix #1007 

If running rootless the default user uses `/.ssh` instead of `/root/.ssh` as the ssh directory.