### PR TITLE
chore: update troubleshooting SFTP documentation

### DIFF
--- a/docs/content/3.cookbooks/4.ssh-remote.md
+++ b/docs/content/3.cookbooks/4.ssh-remote.md
@@ -116,10 +116,21 @@ docker compose up -d --force-recreate
 
 ## Troubleshooting
 
-- **Connection Errors:** First, test your SSH connection from the host machine to isolate issues. This command uses the exact same configuration files that the container will use.
-  ```bash
+- **Connection Errors:**
+  First, test your SSH connection from the host machine to isolate issues. This command uses the exact same configuration files that the container will use.
+  ```bash host
   # This command should connect without asking for a password
-  ssh -F ./backrest/ssh/config backrest-remote
+  ssh -vF ./backrest/ssh/config -o UserKnownHostsFile=./backrest/ssh/known_hosts backrest-remote
+  # -o UserKnownHostsFile ensures that ssh uses ony the public keys passed to the backrest container instead of the global public keys of the host.
+  ```
+  Attempt connection to the server from the container and compare the results :
+  ```bash host
+  # From the host open a bash terminal to the backrest container
+  docker exec -it backrest bash
+  ```
+  ```bash container
+  # Attempt to connect to the server via ssh. If prompt abort the command, saved keys would be ephemeral.
+  ssh -vF /root/.ssh/config backrest-remote
   ```
 - **Permission Denied:**
   - Double-check the file permissions set in Step 5.


### PR DESCRIPTION
Improved troubleshooting methods: verbose ssh, user known_hosts instead of global while testing connection from host.