### PR TITLE
fix: use cmd.SysProcAttr.HideWindow to spawn background processes on Windows

### DIFF
--- a/internal/platformutil/cmdopts_windows.go
+++ b/internal/platformutil/cmdopts_windows.go
@@ -6,10 +6,11 @@ package platformutil
 import (
 	"os/exec"
 	"syscall"
-
-	"golang.org/x/sys/windows"
 )
 
 func SetPlatformOptions(cmd *exec.Cmd) {
-	cmd.SysProcAttr = &syscall.SysProcAttr{CreationFlags: windows.CREATE_NO_WINDOW}
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.HideWindow = true
 }


### PR DESCRIPTION
Lower risk than the current approach which avoids allocating a console window altogether, should reduce false positives by AV heuristics.