### PR TITLE
fix: use bufio.Reader for reading restic ls --json

### DIFF
--- a/pkg/restic/outputs.go
+++ b/pkg/restic/outputs.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"time"
+	"strings"
 
 	v1 "github.com/garethgeorge/backrest/gen/go/v1"
 )
@@ -301,18 +302,26 @@ func readLs(output io.Reader) (*Snapshot, []*LsEntry, error) {
 
 	var entries []*LsEntry
 	for {
-		bytes, err := reader.ReadBytes('\n')
-		if err != nil {
+		line, err := reader.ReadString('\n')
+		if err != nil && err != io.EOF {
+			return nil, nil, fmt.Errorf("failed to read bytes: %w", err)
+		}
+		trimmed := strings.TrimRight(line, "\r\n")
+		if trimmed == "" {
 			if err == io.EOF {
 				break
 			}
-			return nil, nil, fmt.Errorf("failed to read bytes: %w", err)
+			continue
 		}
+
 		var entry *LsEntry
-		if err := json.Unmarshal(bytes, &entry); err != nil {
+		if err := json.Unmarshal([]byte(trimmed), &entry); err != nil {
 			return nil, nil, fmt.Errorf("failed to parse JSON: %w", err)
 		}
 		entries = append(entries, entry)
+		if err == io.EOF {
+			break
+		}
 	}
 	return snapshot, entries, nil
 }


### PR DESCRIPTION
`restic ls --json` on snapshots created with `restic --files-from-verbatim` lists all paths in the snapshot info line (first line), which can easily exceed the default 64KB token limit of `bufio.Scanner`. This changes it to `bufio.Reader` which reads indefinitely until the token.

Tested on repos that are causing the issue.