### PR TITLE
fix: support for linux/arm/v7

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -37,6 +37,7 @@ builds:
       - arm
     goarm:
       - 6
+      - 7
     ldflags:
       - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}}
   - id: docker-entrypoint
@@ -52,6 +53,7 @@ builds:
       - arm
     goarm:
       - 6
+      - 7
     ldflags:
       - -s -w
   - id: windows
@@ -153,6 +155,21 @@ dockers:
       - linux
       - docker-entrypoint
 
+  - image_templates:
+      - garethgeorge/backrest:{{ .Tag }}-scratch-armv7
+      - ghcr.io/garethgeorge/backrest:{{ .Tag }}-scratch-armv7
+    dockerfile: Dockerfile.scratch
+    use: buildx
+    goarch: arm
+    goarm: 7
+    build_flag_templates:
+      - "--pull"
+      - "--provenance=false"
+      - "--platform=linux/arm/v7"
+    ids:
+      - linux
+      - docker-entrypoint
+
 docker_manifests:
   - name_template: "garethgeorge/backrest:latest"
     image_templates:
@@ -199,41 +216,49 @@ docker_manifests:
       - "garethgeorge/backrest:{{ .Tag }}-scratch-amd64"
       - "garethgeorge/backrest:{{ .Tag }}-scratch-arm64"
       - "garethgeorge/backrest:{{ .Tag }}-scratch-armv6"
+      - "garethgeorge/backrest:{{ .Tag }}-scratch-armv7"
   - name_template: "ghcr.io/garethgeorge/backrest:scratch"
     image_templates:
       - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-scratch-amd64"
       - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-scratch-arm64"
       - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-scratch-armv6"
+      - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-scratch-armv7"
   - name_template: "garethgeorge/backrest:v{{ .Major }}-scratch"
     image_templates:
       - "garethgeorge/backrest:{{ .Tag }}-scratch-amd64"
       - "garethgeorge/backrest:{{ .Tag }}-scratch-arm64"
       - "garethgeorge/backrest:{{ .Tag }}-scratch-armv6"
+      - "garethgeorge/backrest:{{ .Tag }}-scratch-armv7"
   - name_template: "ghcr.io/garethgeorge/backrest:v{{ .Major }}-scratch"
     image_templates:
       - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-scratch-amd64"
       - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-scratch-arm64"
       - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-scratch-armv6"
+      - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-scratch-armv7"
   - name_template: "garethgeorge/backrest:v{{ .Major }}.{{ .Minor }}-scratch"
     image_templates:
       - "garethgeorge/backrest:{{ .Tag }}-scratch-amd64"
       - "garethgeorge/backrest:{{ .Tag }}-scratch-arm64"
       - "garethgeorge/backrest:{{ .Tag }}-scratch-armv6"
+      - "garethgeorge/backrest:{{ .Tag }}-scratch-armv7"
   - name_template: "ghcr.io/garethgeorge/backrest:v{{ .Major }}.{{ .Minor }}-scratch"
     image_templates:
       - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-scratch-amd64"
       - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-scratch-arm64"
       - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-scratch-armv6"
+      - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-scratch-armv7"
   - name_template: "garethgeorge/backrest:{{ .Tag }}-scratch"
     image_templates:
       - "garethgeorge/backrest:{{ .Tag }}-scratch-amd64"
       - "garethgeorge/backrest:{{ .Tag }}-scratch-arm64"
       - "garethgeorge/backrest:{{ .Tag }}-scratch-armv6"
+      - "garethgeorge/backrest:{{ .Tag }}-scratch-armv7"
   - name_template: "ghcr.io/garethgeorge/backrest:{{ .Tag }}-scratch"
     image_templates:
       - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-scratch-amd64"
       - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-scratch-arm64"
       - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-scratch-armv6"
+      - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-scratch-armv7"
 
 brews:
   - name: backrest


### PR DESCRIPTION
Add support for linux/arm/v7 via the existing goreleaser config. Also tested via running goreleaser.
This should allow me to use backrest on my old raspberry pi. 

<details>
<summary>AI summary of testing</summary>

Adds ARMv7 (GOARM=7) artifacts and Docker images to the release pipeline.

Changes
Builds: Added 7 to goarm in both linux and docker-entrypoint build targets
Docker images: New scratch-armv7 entry mirroring the existing armv6 config (--platform=linux/arm/v7, --provenance=false)
Docker manifests: All 8 scratch manifest entries (Docker Hub + GHCR × 4 tag patterns) now include the armv7 image template
Verification
Ran goreleaser release --snapshot --skip=publish --clean locally:

goreleaser check passes
Full goreleaser snapshot build completes successfully (exit 0, ~6 min)
ARM v7 binaries produced as ELF 32-bit LSB executable, ARM, EABI5 (statically linked)
backrest_Linux_armv7.tar.gz archive created via existing {{ if .Arm }}v{{ .Arm }}{{ end }} naming
All 6 Docker images built successfully:
alpine-amd64 (220MB), alpine-arm64 (211MB)
scratch-amd64 (58.4MB), scratch-arm64 (54.9MB)
scratch-armv6 (54.4MB), scratch-armv7 (54.3MB)
All existing architectures and manifests remain intact

</details>

This along with a new release would complete #1150
