### PR TITLE
chore: switch to the latest Windows runner for releases

### DIFF
--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -77,7 +77,7 @@ jobs:
   installer:
     name: Windows installers
     needs: [goreleaser]
-    runs-on: windows-2022
+    runs-on: windows-latest
 
     steps:
       - name: Checkout


### PR DESCRIPTION
InnoSetup has been finally included in 2025.