### PR TITLE
Build for i386 systems

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -35,6 +35,7 @@ builds:
       - amd64
       - arm64
       - arm
+      - "386"
     goarm:
       - 6
       - 7

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -51,6 +51,7 @@ builds:
       - amd64
       - arm64
       - arm
+      - "386"
     goarm:
       - 6
       - 7
@@ -91,8 +92,8 @@ archives:
 
 dockers:
   - image_templates:
-      - garethgeorge/backrest:{{ .Tag }}-alpine-amd64
-      - ghcr.io/garethgeorge/backrest:{{ .Tag }}-alpine-amd64
+      - pwbriggs/backrest:{{ .Tag }}-alpine-amd64
+      - ghcr.io/pwbriggs/backrest:{{ .Tag }}-alpine-amd64
     dockerfile: Dockerfile.alpine
     use: buildx
     build_flag_templates:
@@ -103,8 +104,8 @@ dockers:
       - docker-entrypoint
 
   - image_templates:
-      - garethgeorge/backrest:{{ .Tag }}-alpine-arm64
-      - ghcr.io/garethgeorge/backrest:{{ .Tag }}-alpine-arm64
+      - pwbriggs/backrest:{{ .Tag }}-alpine-arm64
+      - ghcr.io/pwbriggs/backrest:{{ .Tag }}-alpine-arm64
     dockerfile: Dockerfile.alpine
     goarch: arm64
     use: buildx
@@ -116,8 +117,8 @@ dockers:
       - docker-entrypoint
 
   - image_templates:
-      - garethgeorge/backrest:{{ .Tag }}-alpine-armv6
-      - ghcr.io/garethgeorge/backrest:{{ .Tag }}-alpine-armv6
+      - pwbriggs/backrest:{{ .Tag }}-alpine-armv6
+      - ghcr.io/pwbriggs/backrest:{{ .Tag }}-alpine-armv6
     dockerfile: Dockerfile.alpine
     use: buildx
     goarch: arm
@@ -131,8 +132,8 @@ dockers:
       - docker-entrypoint
 
   - image_templates:
-      - garethgeorge/backrest:{{ .Tag }}-alpine-armv7
-      - ghcr.io/garethgeorge/backrest:{{ .Tag }}-alpine-armv7
+      - pwbriggs/backrest:{{ .Tag }}-alpine-armv7
+      - ghcr.io/pwbriggs/backrest:{{ .Tag }}-alpine-armv7
     dockerfile: Dockerfile.alpine
     use: buildx
     goarch: arm
@@ -146,8 +147,23 @@ dockers:
       - docker-entrypoint
 
   - image_templates:
-      - garethgeorge/backrest:{{ .Tag }}-scratch-arm64
-      - ghcr.io/garethgeorge/backrest:{{ .Tag }}-scratch-arm64
+      - pwbriggs/backrest:{{ .Tag }}-alpine-386
+      - ghcr.io/pwbriggs/backrest:{{ .Tag }}-alpine-386
+    dockerfile: Dockerfile.alpine
+    use: buildx
+    goarch: "386"
+    goarm: 7
+    build_flag_templates:
+      - "--pull"
+      - "--provenance=false"
+      - "--platform=linux/386"
+    ids:
+      - linux
+      - docker-entrypoint
+
+  - image_templates:
+      - pwbriggs/backrest:{{ .Tag }}-scratch-arm64
+      - ghcr.io/pwbriggs/backrest:{{ .Tag }}-scratch-arm64
     dockerfile: Dockerfile.scratch
     goarch: arm64
     use: buildx
@@ -159,8 +175,8 @@ dockers:
       - docker-entrypoint
 
   - image_templates:
-      - garethgeorge/backrest:{{ .Tag }}-scratch-amd64
-      - ghcr.io/garethgeorge/backrest:{{ .Tag }}-scratch-amd64
+      - pwbriggs/backrest:{{ .Tag }}-scratch-amd64
+      - ghcr.io/pwbriggs/backrest:{{ .Tag }}-scratch-amd64
     dockerfile: Dockerfile.scratch
     use: buildx
     build_flag_templates:
@@ -171,8 +187,8 @@ dockers:
       - docker-entrypoint
 
   - image_templates:
-      - garethgeorge/backrest:{{ .Tag }}-scratch-armv6
-      - ghcr.io/garethgeorge/backrest:{{ .Tag }}-scratch-armv6
+      - pwbriggs/backrest:{{ .Tag }}-scratch-armv6
+      - ghcr.io/pwbriggs/backrest:{{ .Tag }}-scratch-armv6
     dockerfile: Dockerfile.scratch
     use: buildx
     goarch: arm
@@ -186,8 +202,8 @@ dockers:
       - docker-entrypoint
 
   - image_templates:
-      - garethgeorge/backrest:{{ .Tag }}-scratch-armv7
-      - ghcr.io/garethgeorge/backrest:{{ .Tag }}-scratch-armv7
+      - pwbriggs/backrest:{{ .Tag }}-scratch-armv7
+      - ghcr.io/pwbriggs/backrest:{{ .Tag }}-scratch-armv7
     dockerfile: Dockerfile.scratch
     use: buildx
     goarch: arm
@@ -196,133 +212,166 @@ dockers:
       - "--pull"
       - "--provenance=false"
       - "--platform=linux/arm/v7"
+    ids:
+      - linux
+      - docker-entrypoint
+
+  - image_templates:
+      - pwbriggs/backrest:{{ .Tag }}-scratch-386
+      - ghcr.io/pwbriggs/backrest:{{ .Tag }}-scratch-386
+    dockerfile: Dockerfile.scratch
+    use: buildx
+    goarch: "386"
+    goarm: 7
+    build_flag_templates:
+      - "--pull"
+      - "--provenance=false"
+      - "--platform=linux/386"
     ids:
       - linux
       - docker-entrypoint
 
 docker_manifests:
-  - name_template: "garethgeorge/backrest:latest"
+  - name_template: "pwbriggs/backrest:latest"
     image_templates:
-      - "garethgeorge/backrest:{{ .Tag }}-alpine-amd64"
-      - "garethgeorge/backrest:{{ .Tag }}-alpine-arm64"
-      - "garethgeorge/backrest:{{ .Tag }}-alpine-armv6"
-      - "garethgeorge/backrest:{{ .Tag }}-alpine-armv7"
-  - name_template: "ghcr.io/garethgeorge/backrest:latest"
+      - "pwbriggs/backrest:{{ .Tag }}-alpine-amd64"
+      - "pwbriggs/backrest:{{ .Tag }}-alpine-arm64"
+      - "pwbriggs/backrest:{{ .Tag }}-alpine-armv6"
+      - "pwbriggs/backrest:{{ .Tag }}-alpine-armv7"
+      - "pwbriggs/backrest:{{ .Tag }}-alpine-386"
+  - name_template: "ghcr.io/pwbriggs/backrest:latest"
     image_templates:
-      - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-alpine-amd64"
-      - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-alpine-arm64"
-      - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-alpine-armv6"
-      - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-alpine-armv7"
-  - name_template: "garethgeorge/backrest:v{{ .Major }}"
+      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-alpine-amd64"
+      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-alpine-arm64"
+      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-alpine-armv6"
+      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-alpine-armv7"
+      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-alpine-386"
+  - name_template: "pwbriggs/backrest:v{{ .Major }}"
     image_templates:
-      - "garethgeorge/backrest:{{ .Tag }}-alpine-amd64"
-      - "garethgeorge/backrest:{{ .Tag }}-alpine-arm64"
-      - "garethgeorge/backrest:{{ .Tag }}-alpine-armv6"
-      - "garethgeorge/backrest:{{ .Tag }}-alpine-armv7"
-  - name_template: "ghcr.io/garethgeorge/backrest:v{{ .Major }}"
+      - "pwbriggs/backrest:{{ .Tag }}-alpine-amd64"
+      - "pwbriggs/backrest:{{ .Tag }}-alpine-arm64"
+      - "pwbriggs/backrest:{{ .Tag }}-alpine-armv6"
+      - "pwbriggs/backrest:{{ .Tag }}-alpine-armv7"
+      - "pwbriggs/backrest:{{ .Tag }}-alpine-386"
+  - name_template: "ghcr.io/pwbriggs/backrest:v{{ .Major }}"
     image_templates:
-      - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-alpine-amd64"
-      - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-alpine-arm64"
-      - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-alpine-armv6"
-      - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-alpine-armv7"
-  - name_template: "garethgeorge/backrest:v{{ .Major }}.{{ .Minor }}"
+      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-alpine-amd64"
+      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-alpine-arm64"
+      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-alpine-armv6"
+      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-alpine-armv7"
+      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-alpine-386"
+  - name_template: "pwbriggs/backrest:v{{ .Major }}.{{ .Minor }}"
     image_templates:
-      - "garethgeorge/backrest:{{ .Tag }}-alpine-amd64"
-      - "garethgeorge/backrest:{{ .Tag }}-alpine-arm64"
-      - "garethgeorge/backrest:{{ .Tag }}-alpine-armv6"
-      - "garethgeorge/backrest:{{ .Tag }}-alpine-armv7"
-  - name_template: "ghcr.io/garethgeorge/backrest:v{{ .Major }}.{{ .Minor }}"
+      - "pwbriggs/backrest:{{ .Tag }}-alpine-amd64"
+      - "pwbriggs/backrest:{{ .Tag }}-alpine-arm64"
+      - "pwbriggs/backrest:{{ .Tag }}-alpine-armv6"
+      - "pwbriggs/backrest:{{ .Tag }}-alpine-armv7"
+      - "pwbriggs/backrest:{{ .Tag }}-alpine-386"
+  - name_template: "ghcr.io/pwbriggs/backrest:v{{ .Major }}.{{ .Minor }}"
     image_templates:
-      - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-alpine-amd64"
-      - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-alpine-arm64"
-      - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-alpine-armv6"
-      - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-alpine-armv7"
-  - name_template: "garethgeorge/backrest:{{ .Tag }}"
+      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-alpine-amd64"
+      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-alpine-arm64"
+      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-alpine-armv6"
+      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-alpine-armv7"
+      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-alpine-386"
+  - name_template: "pwbriggs/backrest:{{ .Tag }}"
     image_templates:
-      - "garethgeorge/backrest:{{ .Tag }}-alpine-amd64"
-      - "garethgeorge/backrest:{{ .Tag }}-alpine-arm64"
-      - "garethgeorge/backrest:{{ .Tag }}-alpine-armv6"
-      - "garethgeorge/backrest:{{ .Tag }}-alpine-armv7"
-  - name_template: "ghcr.io/garethgeorge/backrest:{{ .Tag }}"
+      - "pwbriggs/backrest:{{ .Tag }}-alpine-amd64"
+      - "pwbriggs/backrest:{{ .Tag }}-alpine-arm64"
+      - "pwbriggs/backrest:{{ .Tag }}-alpine-armv6"
+      - "pwbriggs/backrest:{{ .Tag }}-alpine-armv7"
+      - "pwbriggs/backrest:{{ .Tag }}-alpine-386"
+  - name_template: "ghcr.io/pwbriggs/backrest:{{ .Tag }}"
     image_templates:
-      - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-alpine-amd64"
-      - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-alpine-arm64"
-      - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-alpine-armv6"
-      - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-alpine-armv7"
-  - name_template: "garethgeorge/backrest:latest-alpine"
+      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-alpine-amd64"
+      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-alpine-arm64"
+      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-alpine-armv6"
+      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-alpine-armv7"
+      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-alpine-386"
+  - name_template: "pwbriggs/backrest:latest-alpine"
     image_templates:
-      - "garethgeorge/backrest:{{ .Tag }}-alpine-amd64"
-      - "garethgeorge/backrest:{{ .Tag }}-alpine-arm64"
-      - "garethgeorge/backrest:{{ .Tag }}-alpine-armv6"
-      - "garethgeorge/backrest:{{ .Tag }}-alpine-armv7"
-  - name_template: "ghcr.io/garethgeorge/backrest:latest-alpine"
+      - "pwbriggs/backrest:{{ .Tag }}-alpine-amd64"
+      - "pwbriggs/backrest:{{ .Tag }}-alpine-arm64"
+      - "pwbriggs/backrest:{{ .Tag }}-alpine-armv6"
+      - "pwbriggs/backrest:{{ .Tag }}-alpine-armv7"
+      - "pwbriggs/backrest:{{ .Tag }}-alpine-386"
+  - name_template: "ghcr.io/pwbriggs/backrest:latest-alpine"
     image_templates:
-      - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-alpine-amd64"
-      - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-alpine-arm64"
-      - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-alpine-armv6"
-      - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-alpine-armv7"
-  - name_template: "garethgeorge/backrest:scratch"
+      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-alpine-amd64"
+      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-alpine-arm64"
+      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-alpine-armv6"
+      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-alpine-armv7"
+      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-alpine-386"
+  - name_template: "pwbriggs/backrest:scratch"
     image_templates:
-      - "garethgeorge/backrest:{{ .Tag }}-scratch-amd64"
-      - "garethgeorge/backrest:{{ .Tag }}-scratch-arm64"
-      - "garethgeorge/backrest:{{ .Tag }}-scratch-armv6"
-      - "garethgeorge/backrest:{{ .Tag }}-scratch-armv7"
-  - name_template: "ghcr.io/garethgeorge/backrest:scratch"
+      - "pwbriggs/backrest:{{ .Tag }}-scratch-amd64"
+      - "pwbriggs/backrest:{{ .Tag }}-scratch-arm64"
+      - "pwbriggs/backrest:{{ .Tag }}-scratch-armv6"
+      - "pwbriggs/backrest:{{ .Tag }}-scratch-armv7"
+      - "pwbriggs/backrest:{{ .Tag }}-scratch-386"
+  - name_template: "ghcr.io/pwbriggs/backrest:scratch"
     image_templates:
-      - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-scratch-amd64"
-      - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-scratch-arm64"
-      - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-scratch-armv6"
-      - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-scratch-armv7"
-  - name_template: "garethgeorge/backrest:v{{ .Major }}-scratch"
+      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-scratch-amd64"
+      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-scratch-arm64"
+      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-scratch-armv6"
+      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-scratch-armv7"
+      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-scratch-386"
+  - name_template: "pwbriggs/backrest:v{{ .Major }}-scratch"
     image_templates:
-      - "garethgeorge/backrest:{{ .Tag }}-scratch-amd64"
-      - "garethgeorge/backrest:{{ .Tag }}-scratch-arm64"
-      - "garethgeorge/backrest:{{ .Tag }}-scratch-armv6"
-      - "garethgeorge/backrest:{{ .Tag }}-scratch-armv7"
-  - name_template: "ghcr.io/garethgeorge/backrest:v{{ .Major }}-scratch"
+      - "pwbriggs/backrest:{{ .Tag }}-scratch-amd64"
+      - "pwbriggs/backrest:{{ .Tag }}-scratch-arm64"
+      - "pwbriggs/backrest:{{ .Tag }}-scratch-armv6"
+      - "pwbriggs/backrest:{{ .Tag }}-scratch-armv7"
+      - "pwbriggs/backrest:{{ .Tag }}-scratch-386"
+  - name_template: "ghcr.io/pwbriggs/backrest:v{{ .Major }}-scratch"
     image_templates:
-      - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-scratch-amd64"
-      - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-scratch-arm64"
-      - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-scratch-armv6"
-      - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-scratch-armv7"
-  - name_template: "garethgeorge/backrest:v{{ .Major }}.{{ .Minor }}-scratch"
+      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-scratch-amd64"
+      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-scratch-arm64"
+      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-scratch-armv6"
+      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-scratch-armv7"
+      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-scratch-386"
+  - name_template: "pwbriggs/backrest:v{{ .Major }}.{{ .Minor }}-scratch"
     image_templates:
-      - "garethgeorge/backrest:{{ .Tag }}-scratch-amd64"
-      - "garethgeorge/backrest:{{ .Tag }}-scratch-arm64"
-      - "garethgeorge/backrest:{{ .Tag }}-scratch-armv6"
-      - "garethgeorge/backrest:{{ .Tag }}-scratch-armv7"
-  - name_template: "ghcr.io/garethgeorge/backrest:v{{ .Major }}.{{ .Minor }}-scratch"
+      - "pwbriggs/backrest:{{ .Tag }}-scratch-amd64"
+      - "pwbriggs/backrest:{{ .Tag }}-scratch-arm64"
+      - "pwbriggs/backrest:{{ .Tag }}-scratch-armv6"
+      - "pwbriggs/backrest:{{ .Tag }}-scratch-armv7"
+      - "pwbriggs/backrest:{{ .Tag }}-scratch-386"
+  - name_template: "ghcr.io/pwbriggs/backrest:v{{ .Major }}.{{ .Minor }}-scratch"
     image_templates:
-      - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-scratch-amd64"
-      - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-scratch-arm64"
-      - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-scratch-armv6"
-      - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-scratch-armv7"
-  - name_template: "garethgeorge/backrest:{{ .Tag }}-scratch"
+      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-scratch-amd64"
+      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-scratch-arm64"
+      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-scratch-armv6"
+      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-scratch-armv7"
+      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-scratch-386"
+  - name_template: "pwbriggs/backrest:{{ .Tag }}-scratch"
     image_templates:
-      - "garethgeorge/backrest:{{ .Tag }}-scratch-amd64"
-      - "garethgeorge/backrest:{{ .Tag }}-scratch-arm64"
-      - "garethgeorge/backrest:{{ .Tag }}-scratch-armv6"
-      - "garethgeorge/backrest:{{ .Tag }}-scratch-armv7"
-  - name_template: "ghcr.io/garethgeorge/backrest:{{ .Tag }}-scratch"
+      - "pwbriggs/backrest:{{ .Tag }}-scratch-amd64"
+      - "pwbriggs/backrest:{{ .Tag }}-scratch-arm64"
+      - "pwbriggs/backrest:{{ .Tag }}-scratch-armv6"
+      - "pwbriggs/backrest:{{ .Tag }}-scratch-armv7"
+      - "pwbriggs/backrest:{{ .Tag }}-scratch-386"
+  - name_template: "ghcr.io/pwbriggs/backrest:{{ .Tag }}-scratch"
     image_templates:
-      - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-scratch-amd64"
-      - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-scratch-arm64"
-      - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-scratch-armv6"
-      - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-scratch-armv7"
+      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-scratch-amd64"
+      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-scratch-arm64"
+      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-scratch-armv6"
+      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-scratch-armv7"
+      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-scratch-386"
 
 brews:
   - name: backrest
-    homepage: https://github.com/garethgeorge/backrest
+    homepage: https://github.com/pwbriggs/backrest
     description: "Backrest is a web UI and orchestrator for restic backup."
 
-    url_template: "https://github.com/garethgeorge/backrest/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
+    url_template: "https://github.com/pwbriggs/backrest/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
 
     commit_author:
       name: goreleaserbot
       email: bot@goreleaser.com
 
     repository:
-      owner: garethgeorge
+      owner: pwbriggs
       name: homebrew-backrest-tap
       branch: main
       token: "{{ .Env.HOMEBREW_GITHUB_TOKEN }}"
@@ -341,5 +390,5 @@ changelog:
 
 release:
   github:
-    owner: garethgeorge
+    owner: pwbriggs
     name: backrest

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -92,8 +92,8 @@ archives:
 
 dockers:
   - image_templates:
-      - pwbriggs/backrest:{{ .Tag }}-alpine-amd64
-      - ghcr.io/pwbriggs/backrest:{{ .Tag }}-alpine-amd64
+      - garethgeorge/backrest:{{ .Tag }}-alpine-amd64
+      - ghcr.io/garethgeorge/backrest:{{ .Tag }}-alpine-amd64
     dockerfile: Dockerfile.alpine
     use: buildx
     build_flag_templates:
@@ -104,8 +104,8 @@ dockers:
       - docker-entrypoint
 
   - image_templates:
-      - pwbriggs/backrest:{{ .Tag }}-alpine-arm64
-      - ghcr.io/pwbriggs/backrest:{{ .Tag }}-alpine-arm64
+      - garethgeorge/backrest:{{ .Tag }}-alpine-arm64
+      - ghcr.io/garethgeorge/backrest:{{ .Tag }}-alpine-arm64
     dockerfile: Dockerfile.alpine
     goarch: arm64
     use: buildx
@@ -117,8 +117,8 @@ dockers:
       - docker-entrypoint
 
   - image_templates:
-      - pwbriggs/backrest:{{ .Tag }}-alpine-armv6
-      - ghcr.io/pwbriggs/backrest:{{ .Tag }}-alpine-armv6
+      - garethgeorge/backrest:{{ .Tag }}-alpine-armv6
+      - ghcr.io/garethgeorge/backrest:{{ .Tag }}-alpine-armv6
     dockerfile: Dockerfile.alpine
     use: buildx
     goarch: arm
@@ -132,8 +132,8 @@ dockers:
       - docker-entrypoint
 
   - image_templates:
-      - pwbriggs/backrest:{{ .Tag }}-alpine-armv7
-      - ghcr.io/pwbriggs/backrest:{{ .Tag }}-alpine-armv7
+      - garethgeorge/backrest:{{ .Tag }}-alpine-armv7
+      - ghcr.io/garethgeorge/backrest:{{ .Tag }}-alpine-armv7
     dockerfile: Dockerfile.alpine
     use: buildx
     goarch: arm
@@ -147,8 +147,8 @@ dockers:
       - docker-entrypoint
 
   - image_templates:
-      - pwbriggs/backrest:{{ .Tag }}-alpine-386
-      - ghcr.io/pwbriggs/backrest:{{ .Tag }}-alpine-386
+      - garethgeorge/backrest:{{ .Tag }}-alpine-386
+      - ghcr.io/garethgeorge/backrest:{{ .Tag }}-alpine-386
     dockerfile: Dockerfile.alpine
     use: buildx
     goarch: "386"
@@ -162,8 +162,8 @@ dockers:
       - docker-entrypoint
 
   - image_templates:
-      - pwbriggs/backrest:{{ .Tag }}-scratch-arm64
-      - ghcr.io/pwbriggs/backrest:{{ .Tag }}-scratch-arm64
+      - garethgeorge/backrest:{{ .Tag }}-scratch-arm64
+      - ghcr.io/garethgeorge/backrest:{{ .Tag }}-scratch-arm64
     dockerfile: Dockerfile.scratch
     goarch: arm64
     use: buildx
@@ -175,8 +175,8 @@ dockers:
       - docker-entrypoint
 
   - image_templates:
-      - pwbriggs/backrest:{{ .Tag }}-scratch-amd64
-      - ghcr.io/pwbriggs/backrest:{{ .Tag }}-scratch-amd64
+      - garethgeorge/backrest:{{ .Tag }}-scratch-amd64
+      - ghcr.io/garethgeorge/backrest:{{ .Tag }}-scratch-amd64
     dockerfile: Dockerfile.scratch
     use: buildx
     build_flag_templates:
@@ -187,8 +187,8 @@ dockers:
       - docker-entrypoint
 
   - image_templates:
-      - pwbriggs/backrest:{{ .Tag }}-scratch-armv6
-      - ghcr.io/pwbriggs/backrest:{{ .Tag }}-scratch-armv6
+      - garethgeorge/backrest:{{ .Tag }}-scratch-armv6
+      - ghcr.io/garethgeorge/backrest:{{ .Tag }}-scratch-armv6
     dockerfile: Dockerfile.scratch
     use: buildx
     goarch: arm
@@ -202,8 +202,8 @@ dockers:
       - docker-entrypoint
 
   - image_templates:
-      - pwbriggs/backrest:{{ .Tag }}-scratch-armv7
-      - ghcr.io/pwbriggs/backrest:{{ .Tag }}-scratch-armv7
+      - garethgeorge/backrest:{{ .Tag }}-scratch-armv7
+      - ghcr.io/garethgeorge/backrest:{{ .Tag }}-scratch-armv7
     dockerfile: Dockerfile.scratch
     use: buildx
     goarch: arm
@@ -217,8 +217,8 @@ dockers:
       - docker-entrypoint
 
   - image_templates:
-      - pwbriggs/backrest:{{ .Tag }}-scratch-386
-      - ghcr.io/pwbriggs/backrest:{{ .Tag }}-scratch-386
+      - garethgeorge/backrest:{{ .Tag }}-scratch-386
+      - ghcr.io/garethgeorge/backrest:{{ .Tag }}-scratch-386
     dockerfile: Dockerfile.scratch
     use: buildx
     goarch: "386"
@@ -232,146 +232,146 @@ dockers:
       - docker-entrypoint
 
 docker_manifests:
-  - name_template: "pwbriggs/backrest:latest"
+  - name_template: "garethgeorge/backrest:latest"
     image_templates:
-      - "pwbriggs/backrest:{{ .Tag }}-alpine-amd64"
-      - "pwbriggs/backrest:{{ .Tag }}-alpine-arm64"
-      - "pwbriggs/backrest:{{ .Tag }}-alpine-armv6"
-      - "pwbriggs/backrest:{{ .Tag }}-alpine-armv7"
-      - "pwbriggs/backrest:{{ .Tag }}-alpine-386"
-  - name_template: "ghcr.io/pwbriggs/backrest:latest"
+      - "garethgeorge/backrest:{{ .Tag }}-alpine-amd64"
+      - "garethgeorge/backrest:{{ .Tag }}-alpine-arm64"
+      - "garethgeorge/backrest:{{ .Tag }}-alpine-armv6"
+      - "garethgeorge/backrest:{{ .Tag }}-alpine-armv7"
+      - "garethgeorge/backrest:{{ .Tag }}-alpine-386"
+  - name_template: "ghcr.io/garethgeorge/backrest:latest"
     image_templates:
-      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-alpine-amd64"
-      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-alpine-arm64"
-      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-alpine-armv6"
-      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-alpine-armv7"
-      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-alpine-386"
-  - name_template: "pwbriggs/backrest:v{{ .Major }}"
+      - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-alpine-amd64"
+      - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-alpine-arm64"
+      - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-alpine-armv6"
+      - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-alpine-armv7"
+      - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-alpine-386"
+  - name_template: "garethgeorge/backrest:v{{ .Major }}"
     image_templates:
-      - "pwbriggs/backrest:{{ .Tag }}-alpine-amd64"
-      - "pwbriggs/backrest:{{ .Tag }}-alpine-arm64"
-      - "pwbriggs/backrest:{{ .Tag }}-alpine-armv6"
-      - "pwbriggs/backrest:{{ .Tag }}-alpine-armv7"
-      - "pwbriggs/backrest:{{ .Tag }}-alpine-386"
-  - name_template: "ghcr.io/pwbriggs/backrest:v{{ .Major }}"
+      - "garethgeorge/backrest:{{ .Tag }}-alpine-amd64"
+      - "garethgeorge/backrest:{{ .Tag }}-alpine-arm64"
+      - "garethgeorge/backrest:{{ .Tag }}-alpine-armv6"
+      - "garethgeorge/backrest:{{ .Tag }}-alpine-armv7"
+      - "garethgeorge/backrest:{{ .Tag }}-alpine-386"
+  - name_template: "ghcr.io/garethgeorge/backrest:v{{ .Major }}"
     image_templates:
-      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-alpine-amd64"
-      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-alpine-arm64"
-      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-alpine-armv6"
-      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-alpine-armv7"
-      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-alpine-386"
-  - name_template: "pwbriggs/backrest:v{{ .Major }}.{{ .Minor }}"
+      - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-alpine-amd64"
+      - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-alpine-arm64"
+      - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-alpine-armv6"
+      - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-alpine-armv7"
+      - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-alpine-386"
+  - name_template: "garethgeorge/backrest:v{{ .Major }}.{{ .Minor }}"
     image_templates:
-      - "pwbriggs/backrest:{{ .Tag }}-alpine-amd64"
-      - "pwbriggs/backrest:{{ .Tag }}-alpine-arm64"
-      - "pwbriggs/backrest:{{ .Tag }}-alpine-armv6"
-      - "pwbriggs/backrest:{{ .Tag }}-alpine-armv7"
-      - "pwbriggs/backrest:{{ .Tag }}-alpine-386"
-  - name_template: "ghcr.io/pwbriggs/backrest:v{{ .Major }}.{{ .Minor }}"
+      - "garethgeorge/backrest:{{ .Tag }}-alpine-amd64"
+      - "garethgeorge/backrest:{{ .Tag }}-alpine-arm64"
+      - "garethgeorge/backrest:{{ .Tag }}-alpine-armv6"
+      - "garethgeorge/backrest:{{ .Tag }}-alpine-armv7"
+      - "garethgeorge/backrest:{{ .Tag }}-alpine-386"
+  - name_template: "ghcr.io/garethgeorge/backrest:v{{ .Major }}.{{ .Minor }}"
     image_templates:
-      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-alpine-amd64"
-      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-alpine-arm64"
-      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-alpine-armv6"
-      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-alpine-armv7"
-      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-alpine-386"
-  - name_template: "pwbriggs/backrest:{{ .Tag }}"
+      - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-alpine-amd64"
+      - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-alpine-arm64"
+      - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-alpine-armv6"
+      - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-alpine-armv7"
+      - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-alpine-386"
+  - name_template: "garethgeorge/backrest:{{ .Tag }}"
     image_templates:
-      - "pwbriggs/backrest:{{ .Tag }}-alpine-amd64"
-      - "pwbriggs/backrest:{{ .Tag }}-alpine-arm64"
-      - "pwbriggs/backrest:{{ .Tag }}-alpine-armv6"
-      - "pwbriggs/backrest:{{ .Tag }}-alpine-armv7"
-      - "pwbriggs/backrest:{{ .Tag }}-alpine-386"
-  - name_template: "ghcr.io/pwbriggs/backrest:{{ .Tag }}"
+      - "garethgeorge/backrest:{{ .Tag }}-alpine-amd64"
+      - "garethgeorge/backrest:{{ .Tag }}-alpine-arm64"
+      - "garethgeorge/backrest:{{ .Tag }}-alpine-armv6"
+      - "garethgeorge/backrest:{{ .Tag }}-alpine-armv7"
+      - "garethgeorge/backrest:{{ .Tag }}-alpine-386"
+  - name_template: "ghcr.io/garethgeorge/backrest:{{ .Tag }}"
     image_templates:
-      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-alpine-amd64"
-      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-alpine-arm64"
-      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-alpine-armv6"
-      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-alpine-armv7"
-      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-alpine-386"
-  - name_template: "pwbriggs/backrest:latest-alpine"
+      - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-alpine-amd64"
+      - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-alpine-arm64"
+      - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-alpine-armv6"
+      - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-alpine-armv7"
+      - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-alpine-386"
+  - name_template: "garethgeorge/backrest:latest-alpine"
     image_templates:
-      - "pwbriggs/backrest:{{ .Tag }}-alpine-amd64"
-      - "pwbriggs/backrest:{{ .Tag }}-alpine-arm64"
-      - "pwbriggs/backrest:{{ .Tag }}-alpine-armv6"
-      - "pwbriggs/backrest:{{ .Tag }}-alpine-armv7"
-      - "pwbriggs/backrest:{{ .Tag }}-alpine-386"
-  - name_template: "ghcr.io/pwbriggs/backrest:latest-alpine"
+      - "garethgeorge/backrest:{{ .Tag }}-alpine-amd64"
+      - "garethgeorge/backrest:{{ .Tag }}-alpine-arm64"
+      - "garethgeorge/backrest:{{ .Tag }}-alpine-armv6"
+      - "garethgeorge/backrest:{{ .Tag }}-alpine-armv7"
+      - "garethgeorge/backrest:{{ .Tag }}-alpine-386"
+  - name_template: "ghcr.io/garethgeorge/backrest:latest-alpine"
     image_templates:
-      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-alpine-amd64"
-      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-alpine-arm64"
-      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-alpine-armv6"
-      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-alpine-armv7"
-      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-alpine-386"
-  - name_template: "pwbriggs/backrest:scratch"
+      - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-alpine-amd64"
+      - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-alpine-arm64"
+      - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-alpine-armv6"
+      - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-alpine-armv7"
+      - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-alpine-386"
+  - name_template: "garethgeorge/backrest:scratch"
     image_templates:
-      - "pwbriggs/backrest:{{ .Tag }}-scratch-amd64"
-      - "pwbriggs/backrest:{{ .Tag }}-scratch-arm64"
-      - "pwbriggs/backrest:{{ .Tag }}-scratch-armv6"
-      - "pwbriggs/backrest:{{ .Tag }}-scratch-armv7"
-      - "pwbriggs/backrest:{{ .Tag }}-scratch-386"
-  - name_template: "ghcr.io/pwbriggs/backrest:scratch"
+      - "garethgeorge/backrest:{{ .Tag }}-scratch-amd64"
+      - "garethgeorge/backrest:{{ .Tag }}-scratch-arm64"
+      - "garethgeorge/backrest:{{ .Tag }}-scratch-armv6"
+      - "garethgeorge/backrest:{{ .Tag }}-scratch-armv7"
+      - "garethgeorge/backrest:{{ .Tag }}-scratch-386"
+  - name_template: "ghcr.io/garethgeorge/backrest:scratch"
     image_templates:
-      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-scratch-amd64"
-      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-scratch-arm64"
-      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-scratch-armv6"
-      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-scratch-armv7"
-      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-scratch-386"
-  - name_template: "pwbriggs/backrest:v{{ .Major }}-scratch"
+      - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-scratch-amd64"
+      - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-scratch-arm64"
+      - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-scratch-armv6"
+      - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-scratch-armv7"
+      - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-scratch-386"
+  - name_template: "garethgeorge/backrest:v{{ .Major }}-scratch"
     image_templates:
-      - "pwbriggs/backrest:{{ .Tag }}-scratch-amd64"
-      - "pwbriggs/backrest:{{ .Tag }}-scratch-arm64"
-      - "pwbriggs/backrest:{{ .Tag }}-scratch-armv6"
-      - "pwbriggs/backrest:{{ .Tag }}-scratch-armv7"
-      - "pwbriggs/backrest:{{ .Tag }}-scratch-386"
-  - name_template: "ghcr.io/pwbriggs/backrest:v{{ .Major }}-scratch"
+      - "garethgeorge/backrest:{{ .Tag }}-scratch-amd64"
+      - "garethgeorge/backrest:{{ .Tag }}-scratch-arm64"
+      - "garethgeorge/backrest:{{ .Tag }}-scratch-armv6"
+      - "garethgeorge/backrest:{{ .Tag }}-scratch-armv7"
+      - "garethgeorge/backrest:{{ .Tag }}-scratch-386"
+  - name_template: "ghcr.io/garethgeorge/backrest:v{{ .Major }}-scratch"
     image_templates:
-      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-scratch-amd64"
-      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-scratch-arm64"
-      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-scratch-armv6"
-      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-scratch-armv7"
-      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-scratch-386"
-  - name_template: "pwbriggs/backrest:v{{ .Major }}.{{ .Minor }}-scratch"
+      - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-scratch-amd64"
+      - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-scratch-arm64"
+      - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-scratch-armv6"
+      - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-scratch-armv7"
+      - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-scratch-386"
+  - name_template: "garethgeorge/backrest:v{{ .Major }}.{{ .Minor }}-scratch"
     image_templates:
-      - "pwbriggs/backrest:{{ .Tag }}-scratch-amd64"
-      - "pwbriggs/backrest:{{ .Tag }}-scratch-arm64"
-      - "pwbriggs/backrest:{{ .Tag }}-scratch-armv6"
-      - "pwbriggs/backrest:{{ .Tag }}-scratch-armv7"
-      - "pwbriggs/backrest:{{ .Tag }}-scratch-386"
-  - name_template: "ghcr.io/pwbriggs/backrest:v{{ .Major }}.{{ .Minor }}-scratch"
+      - "garethgeorge/backrest:{{ .Tag }}-scratch-amd64"
+      - "garethgeorge/backrest:{{ .Tag }}-scratch-arm64"
+      - "garethgeorge/backrest:{{ .Tag }}-scratch-armv6"
+      - "garethgeorge/backrest:{{ .Tag }}-scratch-armv7"
+      - "garethgeorge/backrest:{{ .Tag }}-scratch-386"
+  - name_template: "ghcr.io/garethgeorge/backrest:v{{ .Major }}.{{ .Minor }}-scratch"
     image_templates:
-      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-scratch-amd64"
-      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-scratch-arm64"
-      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-scratch-armv6"
-      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-scratch-armv7"
-      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-scratch-386"
-  - name_template: "pwbriggs/backrest:{{ .Tag }}-scratch"
+      - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-scratch-amd64"
+      - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-scratch-arm64"
+      - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-scratch-armv6"
+      - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-scratch-armv7"
+      - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-scratch-386"
+  - name_template: "garethgeorge/backrest:{{ .Tag }}-scratch"
     image_templates:
-      - "pwbriggs/backrest:{{ .Tag }}-scratch-amd64"
-      - "pwbriggs/backrest:{{ .Tag }}-scratch-arm64"
-      - "pwbriggs/backrest:{{ .Tag }}-scratch-armv6"
-      - "pwbriggs/backrest:{{ .Tag }}-scratch-armv7"
-      - "pwbriggs/backrest:{{ .Tag }}-scratch-386"
-  - name_template: "ghcr.io/pwbriggs/backrest:{{ .Tag }}-scratch"
+      - "garethgeorge/backrest:{{ .Tag }}-scratch-amd64"
+      - "garethgeorge/backrest:{{ .Tag }}-scratch-arm64"
+      - "garethgeorge/backrest:{{ .Tag }}-scratch-armv6"
+      - "garethgeorge/backrest:{{ .Tag }}-scratch-armv7"
+      - "garethgeorge/backrest:{{ .Tag }}-scratch-386"
+  - name_template: "ghcr.io/garethgeorge/backrest:{{ .Tag }}-scratch"
     image_templates:
-      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-scratch-amd64"
-      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-scratch-arm64"
-      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-scratch-armv6"
-      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-scratch-armv7"
-      - "ghcr.io/pwbriggs/backrest:{{ .Tag }}-scratch-386"
+      - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-scratch-amd64"
+      - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-scratch-arm64"
+      - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-scratch-armv6"
+      - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-scratch-armv7"
+      - "ghcr.io/garethgeorge/backrest:{{ .Tag }}-scratch-386"
 
 brews:
   - name: backrest
-    homepage: https://github.com/pwbriggs/backrest
+    homepage: https://github.com/garethgeorge/backrest
     description: "Backrest is a web UI and orchestrator for restic backup."
 
-    url_template: "https://github.com/pwbriggs/backrest/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
+    url_template: "https://github.com/garethgeorge/backrest/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
 
     commit_author:
       name: goreleaserbot
       email: bot@goreleaser.com
 
     repository:
-      owner: pwbriggs
+      owner: garethgeorge
       name: homebrew-backrest-tap
       branch: main
       token: "{{ .Env.HOMEBREW_GITHUB_TOKEN }}"
@@ -390,5 +390,5 @@ changelog:
 
 release:
   github:
-    owner: pwbriggs
+    owner: garethgeorge
     name: backrest


### PR DESCRIPTION
Hey! I'm trying to run Backrest on an old 32-bit server box. Would you be willing to build for i386-family systems?

I tested these changes and, to the best of my knowledge, backrest and restic both appear to be functioning okay on my i686 computer.

This would mostly be for my convenience. If you don't want to run these builds (to save on CI minutes or whatever), that's fine too—I can maintain a fork of the repo with the updated GoReleaser.

Thanks! :heart: