### PR TITLE
fix: upgrade devcontainer to fix Dockerfile build errors

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -18,4 +18,4 @@ RUN go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest \
     && go install google.golang.org/protobuf/cmd/protoc-gen-go@latest \
     && go install connectrpc.com/connect/cmd/protoc-gen-connect-go@latest \
     && go install github.com/goreleaser/goreleaser@latest \
-    && npm install -g @bufbuild/protoc-gen-es @connectrpc/protoc-gen-connect-es
+    && npm install -g @bufbuild/protoc-gen-es

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 ## Based on microsoft go devcontainer - https://github.com/microsoft/vscode-dev-containers/blob/v0.205.2/containers/go/.devcontainer/Dockerfile
 # [Choice] Go version (use -bullseye variants on local arm64/Apple Silicon): 1, 1.16, 1.17, 1-bullseye, 1.16-bullseye, 1.17-bullseye, 1-buster, 1.16-buster, 1.17-buster
-ARG VARIANT=1-bullseye
+ARG VARIANT=1-trixie
 FROM mcr.microsoft.com/vscode/devcontainers/go:${VARIANT}
 
 # [Choice] Node.js version: none, lts/*, 16, 14, 12, 10

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -17,6 +17,5 @@ RUN go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest \
     && go install github.com/fullstorydev/grpcurl/cmd/grpcurl@latest \
     && go install google.golang.org/protobuf/cmd/protoc-gen-go@latest \
     && go install connectrpc.com/connect/cmd/protoc-gen-connect-go@latest \
-    && go install github.com/GeertJohan/go.rice/rice@latest \
     && go install github.com/goreleaser/goreleaser@latest \
     && npm install -g @bufbuild/protoc-gen-es @connectrpc/protoc-gen-connect-es

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -17,5 +17,5 @@ RUN go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest \
     && go install github.com/fullstorydev/grpcurl/cmd/grpcurl@latest \
     && go install google.golang.org/protobuf/cmd/protoc-gen-go@latest \
     && go install connectrpc.com/connect/cmd/protoc-gen-connect-go@latest \
-    && go install github.com/goreleaser/goreleaser@latest \
+    && go install github.com/goreleaser/goreleaser/v2@v2.13.3 \
     && npm install -g @bufbuild/protoc-gen-es

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
 USER vscode
 
 RUN go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest \
-    && go install github.com/bufbuild/buf/cmd/buf@v1.27.2 \
+    && go install github.com/bufbuild/buf/cmd/buf@v1.47.2 \
     && go install github.com/fullstorydev/grpcurl/cmd/grpcurl@latest \
     && go install google.golang.org/protobuf/cmd/protoc-gen-go@latest \
     && go install connectrpc.com/connect/cmd/protoc-gen-connect-go@latest \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
       // Update the VARIANT arg to pick a version of Go: 1, 1.16, 1.17
       // Append -bullseye or -buster to pin to an OS version.
       // Use -bullseye variants on local arm64/Apple Silicon.
-      "VARIANT": "1.24-trixie",
+      "VARIANT": "1.25-trixie",
       // Options
       "NODE_VERSION": "lts/*"
     }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
       // Update the VARIANT arg to pick a version of Go: 1, 1.16, 1.17
       // Append -bullseye or -buster to pin to an OS version.
       // Use -bullseye variants on local arm64/Apple Silicon.
-      "VARIANT": "1-1.24-bookworm",
+      "VARIANT": "1.24-trixie",
       // Options
       "NODE_VERSION": "lts/*"
     }
@@ -24,8 +24,8 @@
         "go.useLanguageServer": true,
         "go.gopath": "/go",
         "go.goroot": "/usr/local/go",
-        "typescript.tsdk": "webui/node_modules/typescript/lib",
-        "typescript.enablePromptUseWorkspaceTsdk": true,
+        "js/ts.tsdk.path": "webui/node_modules/typescript/lib",
+        "js/ts.tsdk.promptToUseWorkspaceVersion": true,
         "gitlens.telemetry.enabled": false
       },
       // Add the IDs of extensions you want installed when the container is created.

--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ Contributions are welcome! See the [issues](https://github.com/garethgeorge/back
 ## Build Dependencies
 
 - [Node.js](https://nodejs.org/en) for UI development
-- [Go](https://go.dev/) 1.21 or greater for server development
+- [Go](https://go.dev/) 1.25 or greater for server development
 - [goreleaser](https://github.com/goreleaser/goreleaser) `go install github.com/goreleaser/goreleaser@latest`
 
 **(Optional) To Edit Protobuffers**


### PR DESCRIPTION
I encountered this fatal Dockerfile build error when trying to load the devcontainer for this repo:
```
 > [dev_container_auto_added_stage_label 3/4] RUN apt-get update && export DEBIAN_FRONTEND=noninteractive     && apt-get -y install --no-install-recommends protobuf-compiler:
0.403 Get:1 http://deb.debian.org/debian bookworm InRelease [151 kB]            
0.451 Get:2 https://dl.yarnpkg.com/debian stable InRelease                      
0.464 Get:3 http://deb.debian.org/debian bookworm-updates InRelease [55.4 kB]   
0.484 Get:4 http://deb.debian.org/debian-security bookworm-security InRelease [48.0 kB]
0.550 Get:5 http://deb.debian.org/debian bookworm/main amd64 Packages [8792 kB]
0.584 Err:2 https://dl.yarnpkg.com/debian stable InRelease
0.584   The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 62D54FD4003F6525
0.775 Get:6 http://deb.debian.org/debian bookworm-updates/main amd64 Packages [6924 B]
0.775 Get:7 http://deb.debian.org/debian-security bookworm-security/main amd64 Packages [297 kB]
1.312 Reading package lists...
1.655 W: GPG error: https://dl.yarnpkg.com/debian stable InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 62D54FD4003F6525
1.655 E: The repository 'https://dl.yarnpkg.com/debian stable InRelease' is not signed.
```

Upgrading to Debian trixie as the base container seems to have fixed that issue, but uncovered more warnings/errors loading the devcontainer. Fixed those with the following:
- switched to "modern" config names for the tsdk options following warnings in VSCode
- upgraded go to v1.25 to match go.mod
- pin goreleaser to a version that supports go v1.25 (v2.13.3)

Not errors but also changed in this PR:
- updated readme development instructions to require v1.25 to match go.mod
- removed `@connectrpc/protoc-gen-connect-es` to match d9553509737d19fb643f61d6c15ed019ab26ff9f
- removed `rice` to match e3ba5cf12ebfedafaa2125687bd7522f29ccab51