### PR TITLE
fix: show repo URI in sidebar tooltip instead of repo ID

### DIFF
--- a/webui/src/app/App.tsx
+++ b/webui/src/app/App.tsx
@@ -314,7 +314,7 @@ const SidebarRepoItem = React.memo(
         <Box flexShrink={0} mr={2}>
           <IconForResource selector={sel} />
         </Box>
-        <Tooltip content={repo.id}>
+        <Tooltip content={repo.uri}>
           <Box
             flex="1"
             minW="0"


### PR DESCRIPTION
The tooltip on repo items in the sidebar was showing the repo ID, which is redundant since it's already the visible label. This changes it to show the repo URI (e.g. S3 bucket URL, local path).