### PR TITLE
fix: set proper path to allow using rclone from brew install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -462,8 +462,8 @@ create_launchd_plist() {
     <true/>
     <key>EnvironmentVariables</key>
     <dict>
-        <key>PATH</key>
-        <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+        <key>PATH</key>        
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
         <key>BACKREST_PORT</key>
         <string>$BACKREST_PORT</string>
     </dict>


### PR DESCRIPTION
Fixes #1180
tested when installing backrest 1.13.0

```text
2026-05-04T17:32:57.537+0200	INFO	backrest starting	{"version": "1.13.0", "commit": "a389bbc7e2bd344b9cace3a1bb88f73cb224128f", "log_dir": "/Users/michalsochon/.local/share/backrest/processlogs"}
2026-05-04T17:32:57.631+0200	INFO	restic binary "/opt/homebrew/bin/restic" in $PATH matches required version 0.18.1, it will be used for backrest commands
...
```