### PR TITLE
Added a container build using sqlite3_flock

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -43,6 +43,26 @@ builds:
       - 7
     ldflags:
       - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}}
+  - id: linux-flock
+    main: ./cmd/backrest
+    binary: backrest
+    env:
+      - CGO_ENABLED=0
+    tags:
+      - tray
+      - sqlite3_flock
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm64
+      - arm
+      - "386"
+    goarm:
+      - 6
+      - 7
+    ldflags:
+      - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}}
   - id: docker-entrypoint
     main: ./cmd/docker-entrypoint
     binary: docker-entrypoint
@@ -144,6 +164,30 @@ dockers_v2:
       - "--provenance=false"
     ids:
       - linux
+      - docker-entrypoint
+    platforms:
+      - linux/amd64
+      - linux/arm64
+      - linux/arm/v6
+      - linux/arm/v7
+      - linux/386
+
+  - id: flock
+    images:
+      - garethgeorge/backrest
+      - ghcr.io/garethgeorge/backrest
+    tags:
+      - flock
+      - v{{ .Major }}-flock
+      - v{{ .Major }}.{{ .Minor }}-flock
+      - "{{ .Tag }}-flock"
+    dockerfile: Dockerfile.alpine
+    flags:
+      - "--pull"
+      # provenance attestations break the multi-arch manifest for armv6/armv7/386
+      - "--provenance=false"
+    ids:
+      - linux-flock
       - docker-entrypoint
     platforms:
       - linux/amd64


### PR DESCRIPTION
Added a build option using sqlite3_flock to get a working container for linux servers running older kernel versions as reported in https://github.com/garethgeorge/backrest/issues/978

This needs review. I believe this should work, but I'm not an experienced developer, so it might not 🙃