### PR TITLE
fix(restore): restore single file with [ or ] in name on Windows

### DIFF
--- a/internal/orchestrator/repo/repo.go
+++ b/internal/orchestrator/repo/repo.go
@@ -454,9 +454,28 @@ func chunkBy[T any](items []T, chunkSize int) (chunks [][]T) {
 
 var globEscapeReplacer = strings.NewReplacer(`\`, `\\`, `*`, `\*`, `?`, `\?`, `[`, `\[`, `]`, `\]`)
 
+// On Windows, restic's --include uses Go's path/filepath.Match, which treats
+// '\' as a path separator (not an escape character) and rejects the POSIX
+// class self-escape `[[]` / `[]]` as an invalid pattern. There is therefore
+// no way to express a literal '[' or ']' as a match character on Windows.
+//
+// NTFS forbids '*' and '?' in real filenames, so the single-character
+// wildcard '?' is safe to use as a stand-in for '[' and ']' in a leaf-name
+// pattern: it can never collide with a sibling whose name is exactly the
+// requested file. It may, however, match a same-length sibling whose name
+// differs only in the position of the substituted bracket — typically zero,
+// occasionally one or two real-world siblings.
+//
+// Trade-off: the prior behaviour silently restored zero files when the
+// requested leaf had a bracket in its name (matches no snapshot path).
+// With this fix the requested file is restored; same-length siblings may
+// also land in the target dir. A caller that wants exact-set semantics
+// should sweep the target after restore against the requested path list.
+var windowsBracketReplacer = strings.NewReplacer(`[`, `?`, `]`, `?`)
+
 func escapeGlob(s string) string {
 	if runtime.GOOS == "windows" {
-		return s // escaping is not supported on Windows
+		return windowsBracketReplacer.Replace(s)
 	}
 	return globEscapeReplacer.Replace(s)
 }

--- a/internal/orchestrator/repo/repo_test.go
+++ b/internal/orchestrator/repo/repo_test.go
@@ -97,10 +97,13 @@ func TestBackup(t *testing.T) {
 func TestRestore(t *testing.T) {
 	t.Parallel()
 
-	// Use a filepath that exercises a few of the glob characters to test escaping
-	messyFilePathToTestGlobs := "test.txt"
-	if runtime.GOOS != "windows" {
-		messyFilePathToTestGlobs = "test*?[].txt"
+	// Use a filepath that exercises a few of the glob characters to test escaping.
+	// On Windows, '*' and '?' are forbidden in filenames, so the messy name only
+	// contains the brackets — '[' and ']' are legal in NTFS and are the chars
+	// the Windows path of escapeGlob has to handle without backslash escape.
+	messyFilePathToTestGlobs := "test*?[].txt"
+	if runtime.GOOS == "windows" {
+		messyFilePathToTestGlobs = "test[brackets].txt"
 	}
 
 	testFile := path.Join(t.TempDir(), messyFilePathToTestGlobs)
@@ -143,10 +146,6 @@ func TestRestore(t *testing.T) {
 		t.Fatalf("restore error: %v", err)
 	}
 	t.Logf("restore summary: %+v", restoreSummary)
-
-	if runtime.GOOS == "windows" {
-		return
-	}
 
 	if restoreSummary.FilesRestored != 1 {
 		t.Errorf("expected 1 new file, got %d", restoreSummary.FilesRestored)


### PR DESCRIPTION
## Summary

`internal/orchestrator/repo/repo.go` → `escapeGlob` returned the leaf name unchanged on Windows because Go's `path/filepath.Match` treats `\` as a path separator (not an escape) and rejects the POSIX class self-escape `[[]` / `[]]` as an invalid pattern. The result: an `/v1.Backrest/Restore` RPC whose `snapshotPath` ends in a bracket-bearing leaf name silently restored zero files on Windows. `TestRestore` worked around this by replacing the messy filename with `test.txt` on Windows and returning before any post-restore assertion ran, so the regression had no signal.

## Root cause

```go
// before
func escapeGlob(s string) string {
    if runtime.GOOS == "windows" {
        return s // escaping is not supported on Windows
    }
    return globEscapeReplacer.Replace(s)
}
```

When `snapshotPath = /home/user/Q3 [draft].pdf` on Windows:
1. `dir = /home/user`, `base = Q3 [draft].pdf`
2. `escapeGlob(base)` returns the base verbatim.
3. The restic invocation becomes `restore <snap>:/home/user --include "/Q3 [draft].pdf" --target T`.
4. Restic's `--include` runs Go's `filepath.Match` on the pattern. `[draft]` is treated as a character class matching any of `{d,r,a,f,t}`. The literal filename `Q3 [draft].pdf` doesn't match.
5. Zero files restored. The RPC reports success.

Restic's class self-escape (`[[]` for literal `[`, `[]]` for literal `]`) doesn't work either, restic's `ValidatePatterns` calls `filepath.Match(pattern, pattern)` as a syntax check and Go's matcher returns `ErrBadPattern` for `[[]`. There is no way to express a literal `[` or `]` as a match character on Windows.

Multiple upstream restic threads have asked for a literal-include mode and been closed: [restic#3658](https://github.com/restic/restic/issues/3658) explicitly closed _not planned_. So the fix has to live in Backrest.

## Fix

NTFS forbids `*` and `?` in real filenames, so substituting `[` / `]` with `?` (Go's single-character wildcard) is safe: the pattern can never collide with a sibling whose name is exactly the requested file. It may match a same-length sibling whose name differs only in the position of the substituted bracket, typically zero, occasionally one or two real-world siblings.

```go
var windowsBracketReplacer = strings.NewReplacer(`[`, `?`, `]`, `?`)

func escapeGlob(s string) string {
    if runtime.GOOS == "windows" {
        return windowsBracketReplacer.Replace(s)
    }
    return globEscapeReplacer.Replace(s)
}
```

Trade-off: with this fix the requested file is restored; same-length siblings may also land in the target dir. The prior behaviour, silently restoring zero files, is strictly worse. A caller that wants exact-set semantics can sweep the target after restore against the requested path list.

## Test coverage

The existing `TestRestore` already wanted to exercise glob characters in the filename but had to back off to `test.txt` on Windows and skip the post-restore assertions entirely. With this fix it now uses `test[brackets].txt` on Windows (the only glob chars NTFS legally allows in a filename) and runs the full file-content check on every platform.

```
=== RUN   TestRestore
    repo_test.go:148: restore summary: message_type:\"summary\" total_bytes:11 bytes_restored:11 total_files:1 files_restored:1
--- PASS: TestRestore (5.89s)
PASS
ok  github.com/garethgeorge/backrest/internal/orchestrator/repo  18.406s
```

Full `internal/orchestrator/repo` package suite passes (`go test ./internal/orchestrator/repo` → 18.4s, all green).

## Why I filed this

I'm a maintainer of [Backspace](https://github.com/backspace-backup/backspace), a desktop GUI (currently in initial development) that wraps Backrest on Windows / macOS / Linux. Our E2E matrix caught this on Windows when a synthetic source file with brackets in its name silently dropped from a partial restore, the per-file accounting then reported zero files restored even though the RPC succeeded.

We worked around it on the Backspace side by going around `/v1.Backrest/Restore` and constructing the restic invocation via `RunCommand` using the `snapshotID:subfolder` literal-path syntax plus the same `?`-substitution + post-restore sweep this PR proposes for Backrest. Fixing it in Backrest itself would help every Backrest user on Windows; happy to iterate on the approach if you'd prefer a different shape (e.g. a richer return that lets callers detect the over-restore).