### PR TITLE
Improve snapshot browser single-child expansion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Nix
 result
+.direnv/
 
 /backrest
 /backrest-*

--- a/internal/api/backresthandler.go
+++ b/internal/api/backresthandler.go
@@ -349,13 +349,13 @@ func (s *BackrestHandler) ListSnapshotFiles(ctx context.Context, req *connect.Re
 		return nil, fmt.Errorf("failed to get repo: %w", err)
 	}
 
-	entries, err := repo.ListSnapshotFiles(ctx, query.SnapshotId, query.Path)
+	path, entries, err := repo.ListSnapshotFilesAutoExpandSingleChild(ctx, query.SnapshotId, query.Path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list snapshot files: %w", err)
 	}
 
 	return connect.NewResponse(&v1.ListSnapshotFilesResponse{
-		Path:    query.Path,
+		Path:    path,
 		Entries: entries,
 	}), nil
 }

--- a/internal/orchestrator/repo/list_snapshot_files_test.go
+++ b/internal/orchestrator/repo/list_snapshot_files_test.go
@@ -1,0 +1,50 @@
+package repo
+
+import (
+	"testing"
+
+	v1 "github.com/garethgeorge/backrest/gen/go/v1"
+)
+
+func TestNormalizeSnapshotListPath(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]string{
+		"":          "/",
+		"/":         "/",
+		"foo":       "/foo",
+		"/foo":      "/foo",
+		"/foo/":     "/foo",
+		"/foo/bar/": "/foo/bar",
+	}
+
+	for input, want := range cases {
+		if got := normalizeSnapshotListPath(input); got != want {
+			t.Errorf("normalizeSnapshotListPath(%q) = %q, want %q", input, got, want)
+		}
+	}
+}
+
+func TestDirectSnapshotChildren(t *testing.T) {
+	t.Parallel()
+
+	entries := []*v1.LsEntry{
+		{Path: "/", Type: "directory"},
+		{Path: "/one", Type: "directory"},
+		{Path: "/one/nested", Type: "directory"},
+		{Path: "/two", Type: "file"},
+	}
+
+	children := directSnapshotChildren("/", entries)
+	if len(children) != 2 {
+		t.Fatalf("directSnapshotChildren returned %d entries, want 2", len(children))
+	}
+	if children[0].Path != "/one" || children[1].Path != "/two" {
+		t.Fatalf("directSnapshotChildren returned paths %q and %q, want /one and /two", children[0].Path, children[1].Path)
+	}
+
+	children = directSnapshotChildren("/one/", entries)
+	if len(children) != 1 || children[0].Path != "/one/nested" {
+		t.Fatalf("directSnapshotChildren for /one returned %#v, want only /one/nested", children)
+	}
+}

--- a/internal/orchestrator/repo/repo.go
+++ b/internal/orchestrator/repo/repo.go
@@ -213,6 +213,59 @@ func (r *RepoOrchestrator) ListSnapshotFiles(ctx context.Context, snapshotId str
 	return lsEnts, nil
 }
 
+func (r *RepoOrchestrator) ListSnapshotFilesAutoExpandSingleChild(ctx context.Context, snapshotId string, requestPath string) (string, []*v1.LsEntry, error) {
+	path := normalizeSnapshotListPath(requestPath)
+
+	const maxAutoExpandDepth = 100
+	for range maxAutoExpandDepth {
+		entries, err := r.ListSnapshotFiles(ctx, snapshotId, path)
+		if err != nil {
+			return "", nil, err
+		}
+
+		children := directSnapshotChildren(path, entries)
+		if len(children) != 1 || children[0].Type != "dir" && children[0].Type != "directory" {
+			return path, entries, nil
+		}
+
+		path = normalizeSnapshotListPath(children[0].Path)
+	}
+
+	entries, err := r.ListSnapshotFiles(ctx, snapshotId, path)
+	if err != nil {
+		return "", nil, err
+	}
+	return path, entries, nil
+}
+
+func normalizeSnapshotListPath(path string) string {
+	if path == "" || path == "/" {
+		return "/"
+	}
+	return "/" + strings.Trim(strings.TrimSpace(path), "/")
+}
+
+func directSnapshotChildren(parent string, entries []*v1.LsEntry) []*v1.LsEntry {
+	parent = normalizeSnapshotListPath(parent)
+	prefix := parent
+	if prefix != "/" {
+		prefix += "/"
+	}
+
+	children := make([]*v1.LsEntry, 0, len(entries))
+	for _, entry := range entries {
+		entryPath := normalizeSnapshotListPath(entry.Path)
+		if entryPath == parent || !strings.HasPrefix(entryPath, prefix) {
+			continue
+		}
+		if strings.Contains(strings.TrimPrefix(entryPath, prefix), "/") {
+			continue
+		}
+		children = append(children, entry)
+	}
+	return children
+}
+
 func (r *RepoOrchestrator) Forget(ctx context.Context, policy *v1.RetentionPolicy, opts ...restic.GenericOption) ([]*v1.ResticSnapshot, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/webui/src/features/repositories/SnapshotBrowser.tsx
+++ b/webui/src/features/repositories/SnapshotBrowser.tsx
@@ -133,6 +133,14 @@ export const SnapshotBrowser = ({
   const [expandedKeys, setExpandedKeys] = useState<Set<string>>(new Set());
   const [loadingKeys, setLoadingKeys] = useState<Set<string>>(new Set());
 
+  const entryToNode = (entry: LsEntry): SnapshotNode => ({
+    key: entry.path!,
+    title: <FileNode entry={entry} snapshotOpId={snapshotOpId} />,
+    isLeaf: entry.type === "file",
+    children: entry.type !== "file" ? [] : undefined,
+    entry: entry,
+  });
+
   const respToNodes = (resp: ListSnapshotFilesResponse): SnapshotNode[] => {
     return (
       resp
@@ -140,14 +148,61 @@ export const SnapshotBrowser = ({
         // This is crucial for fixing the infinite recursion / display issues, while ensuring
         // we don't accidentally filter the root node in other contexts (though root is manually init now).
         .filter((entry) => entry.path!.length > resp.path!.length)
-        .map((entry) => ({
-          key: entry.path!,
-          title: <FileNode entry={entry} snapshotOpId={snapshotOpId} />,
-          isLeaf: entry.type === "file",
-          children: entry.type !== "file" ? [] : undefined,
-          entry: entry,
-        }))
+        .map(entryToNode)
     );
+  };
+
+  const snapshotPathSeparator = "/";
+
+  const normalizeSnapshotPath = (path: string) => {
+    if (!path || path === snapshotPathSeparator) return snapshotPathSeparator;
+    return (
+      snapshotPathSeparator +
+      path
+        .split(snapshotPathSeparator)
+        .filter(Boolean)
+        .join(snapshotPathSeparator)
+    );
+  };
+
+  const collapsedRespToNodes = (
+    requestPath: string,
+    resp: ListSnapshotFilesResponse,
+  ): { children: SnapshotNode[]; expandedKeys: string[] } => {
+    const normalizedRequestPath = normalizeSnapshotPath(requestPath);
+    const normalizedResponsePath = normalizeSnapshotPath(resp.path!);
+    const finalChildren = respToNodes(resp);
+
+    if (normalizedResponsePath === normalizedRequestPath) {
+      return { children: finalChildren, expandedKeys: [] };
+    }
+
+    const requestParts = normalizedRequestPath
+      .split(snapshotPathSeparator)
+      .filter(Boolean);
+    const responseParts = normalizedResponsePath
+      .split(snapshotPathSeparator)
+      .filter(Boolean);
+    const chainParts = responseParts.slice(requestParts.length);
+    const expandedKeys: string[] = [];
+    let children = finalChildren;
+
+    for (let i = chainParts.length - 1; i >= 0; i--) {
+      const path = normalizeSnapshotPath(
+        [...requestParts, ...chainParts.slice(0, i + 1)].join(
+          snapshotPathSeparator,
+        ),
+      );
+      expandedKeys.unshift(path);
+      const entry = create(LsEntrySchema, {
+        path,
+        type: "directory",
+        name: chainParts[i],
+      });
+      children = [{ ...entryToNode(entry), children }];
+    }
+
+    return { children, expandedKeys };
   };
 
   useEffect(() => {
@@ -205,6 +260,10 @@ export const SnapshotBrowser = ({
           snapshotId,
         }),
       );
+      const { children, expandedKeys: autoExpandedKeys } = collapsedRespToNodes(
+        key,
+        resp,
+      );
 
       setTreeData((prev) => {
         let toUpdate: SnapshotNode | null = null;
@@ -216,13 +275,23 @@ export const SnapshotBrowser = ({
         if (!toUpdate) return prev;
 
         const toUpdateCopy = { ...toUpdate };
-        toUpdateCopy.children = respToNodes(resp);
+        toUpdateCopy.children = children;
 
         return prev.map((node) => {
           const didUpdate = replaceKeyInTree(node, key, toUpdateCopy);
           return didUpdate || node;
         });
       });
+
+      if (autoExpandedKeys.length > 0) {
+        setExpandedKeys((prev) => {
+          const next = new Set(prev);
+          for (const autoExpandedKey of autoExpandedKeys) {
+            next.add(autoExpandedKey);
+          }
+          return next;
+        });
+      }
     } catch (e: any) {
       alerts.error("Failed to load snapshot files: " + e.message);
     } finally {


### PR DESCRIPTION
## Summary

- Auto-expand single-child snapshot browser paths on the backend until the listing reaches a directory with multiple entries, a file, an empty directory, or the max expansion depth.
- Return the deepest expanded path from `ListSnapshotFiles` so the frontend can reconstruct and render the collapsed path chain with one API request per click.
- Add tests for snapshot path normalization and direct-child filtering.
- Ignore `.direnv/` for local Nix/direnv development state.

## Testing

- `gzip -c /dev/null > webui/dist/index.html.gz && nix shell nixpkgs#go --command go test ./...`
- `nix shell nixpkgs#go --command go test -race ./internal/orchestrator/repo ./internal/api ./webui`
- `cd webui && npm run check`
- `cd webui && npm run build`
- Manual browser test of the snapshot browser against a dev Backrest instance.

## Disclosure

This change was implemented with the help of an AI coding agent. I manually reviewed the code and manually tested the feature before opening this PR.

## Example

https://github.com/user-attachments/assets/57024a0c-8867-4ed2-b660-22218c185a5b


