### PR TITLE
fix: scheduled forget never runs for repos that only receive external snapshots

### DIFF
--- a/internal/orchestrator/tasks/scheduling_test.go
+++ b/internal/orchestrator/tasks/scheduling_test.go
@@ -65,6 +65,14 @@ func TestScheduling(t *testing.T) {
 						Clock: v1.Schedule_CLOCK_LAST_RUN_TIME,
 					},
 				},
+				ForgetPolicy: &v1.ForgetPolicy{
+					Schedule: &v1.Schedule{
+						Schedule: &v1.Schedule_MaxFrequencyHours{
+							MaxFrequencyHours: 1,
+						},
+						Clock: v1.Schedule_CLOCK_LAST_RUN_TIME,
+					},
+				},
 			},
 		},
 		Plans: []*v1.Plan{
@@ -407,6 +415,126 @@ func TestScheduling(t *testing.T) {
 				},
 			},
 			wantTime: farFuture.Add(time.Hour),
+		},
+		{
+			name: "forget schedule relative with backup since last forget",
+			task: NewScheduledForgetTask(repoRelative, "_system_", false),
+			ops: []*v1.Operation{
+				{
+					InstanceId: "instance1",
+					RepoId:     "repo-relative",
+					RepoGuid:   repoRelative.Guid,
+					PlanId:     "_system_",
+					Op: &v1.Operation_OperationForget{
+						OperationForget: &v1.OperationForget{},
+					},
+					UnixTimeStartMs: farFuture.Add(-time.Minute).UnixMilli(),
+					UnixTimeEndMs:   farFuture.UnixMilli(),
+				},
+				{
+					InstanceId: "instance1",
+					RepoId:     "repo-relative",
+					RepoGuid:   repoRelative.Guid,
+					PlanId:     "_system_",
+					Op: &v1.Operation_OperationBackup{
+						OperationBackup: &v1.OperationBackup{},
+					},
+					UnixTimeStartMs: farFuture.Add(time.Minute).UnixMilli(),
+					UnixTimeEndMs:   farFuture.Add(2 * time.Minute).UnixMilli(),
+				},
+			},
+			wantTime: farFuture.Add(time.Hour),
+		},
+		{
+			name: "forget schedule relative with indexed snapshot since last forget",
+			task: NewScheduledForgetTask(repoRelative, "_system_", false),
+			ops: []*v1.Operation{
+				{
+					InstanceId: "instance1",
+					RepoId:     "repo-relative",
+					RepoGuid:   repoRelative.Guid,
+					PlanId:     "_system_",
+					Op: &v1.Operation_OperationForget{
+						OperationForget: &v1.OperationForget{},
+					},
+					UnixTimeStartMs: farFuture.Add(-time.Minute).UnixMilli(),
+					UnixTimeEndMs:   farFuture.UnixMilli(),
+				},
+				{
+					InstanceId: "_unassociated_",
+					RepoId:     "repo-relative",
+					RepoGuid:   repoRelative.Guid,
+					PlanId:     "_unassociated_",
+					Status:     v1.OperationStatus_STATUS_SUCCESS,
+					SnapshotId: testSnapshotID,
+					Op: &v1.Operation_OperationIndexSnapshot{
+						OperationIndexSnapshot: &v1.OperationIndexSnapshot{
+							Snapshot: &v1.ResticSnapshot{
+								Id:         testSnapshotID,
+								UnixTimeMs: farFuture.Add(time.Minute).UnixMilli(),
+							},
+						},
+					},
+					UnixTimeStartMs: farFuture.Add(time.Minute).UnixMilli(),
+					UnixTimeEndMs:   farFuture.Add(time.Minute).UnixMilli(),
+				},
+			},
+			wantTime: farFuture.Add(time.Hour),
+		},
+		{
+			name: "forget schedule relative with nothing since last forget",
+			task: NewScheduledForgetTask(repoRelative, "_system_", false),
+			ops: []*v1.Operation{
+				{
+					InstanceId: "instance1",
+					RepoId:     "repo-relative",
+					RepoGuid:   repoRelative.Guid,
+					PlanId:     "_system_",
+					Op: &v1.Operation_OperationForget{
+						OperationForget: &v1.OperationForget{},
+					},
+					UnixTimeStartMs: farFuture.Add(-time.Minute).UnixMilli(),
+					UnixTimeEndMs:   farFuture.UnixMilli(),
+				},
+			},
+			wantTime: now.Add(time.Hour),
+		},
+		{
+			name: "forget schedule relative with forgotten indexed snapshot since last forget",
+			task: NewScheduledForgetTask(repoRelative, "_system_", false),
+			ops: []*v1.Operation{
+				{
+					InstanceId: "instance1",
+					RepoId:     "repo-relative",
+					RepoGuid:   repoRelative.Guid,
+					PlanId:     "_system_",
+					Op: &v1.Operation_OperationForget{
+						OperationForget: &v1.OperationForget{},
+					},
+					UnixTimeStartMs: farFuture.Add(-time.Minute).UnixMilli(),
+					UnixTimeEndMs:   farFuture.UnixMilli(),
+				},
+				{
+					InstanceId: "_unassociated_",
+					RepoId:     "repo-relative",
+					RepoGuid:   repoRelative.Guid,
+					PlanId:     "_unassociated_",
+					Status:     v1.OperationStatus_STATUS_SUCCESS,
+					SnapshotId: testSnapshotID,
+					Op: &v1.Operation_OperationIndexSnapshot{
+						OperationIndexSnapshot: &v1.OperationIndexSnapshot{
+							Snapshot: &v1.ResticSnapshot{
+								Id:         testSnapshotID,
+								UnixTimeMs: farFuture.Add(time.Minute).UnixMilli(),
+							},
+							Forgot: true,
+						},
+					},
+					UnixTimeStartMs: farFuture.Add(time.Minute).UnixMilli(),
+					UnixTimeEndMs:   farFuture.Add(time.Minute).UnixMilli(),
+				},
+			},
+			wantTime: now.Add(time.Hour),
 		},
 	}
 

--- a/internal/orchestrator/tasks/taskforget.go
+++ b/internal/orchestrator/tasks/taskforget.go
@@ -107,7 +107,7 @@ func (t *ScheduledForgetTask) Next(now time.Time, runner TaskRunner) (ScheduledT
 	}
 
 	var lastRan time.Time
-	var foundBackup bool
+	var foundActivity bool
 	if err := runner.QueryOperations(oplog.Query{}.
 		SetRepoGUID(repoProto.GetGuid()).
 		SetReversed(true), func(op *v1.Operation) error {
@@ -119,12 +119,17 @@ func (t *ScheduledForgetTask) Next(now time.Time, runner TaskRunner) (ScheduledT
 			return oplog.ErrStopIteration
 		}
 		if _, ok := op.Op.(*v1.Operation_OperationBackup); ok {
-			foundBackup = true
+			foundActivity = true
+		} else if indexOp, ok := op.Op.(*v1.Operation_OperationIndexSnapshot); ok && !indexOp.OperationIndexSnapshot.GetForgot() {
+			// Indexed snapshots count as activity too; they are how snapshots
+			// created outside of backrest (e.g. pushed via rest-server) appear
+			// in the oplog.
+			foundActivity = true
 		}
 		return nil
 	}); err != nil {
 		return NeverScheduledTask, fmt.Errorf("finding last scheduled forget run time: %w", err)
-	} else if !foundBackup {
+	} else if !foundActivity {
 		lastRan = now
 	}
 

--- a/internal/orchestrator/tasks/testtaskrunner_test.go
+++ b/internal/orchestrator/tasks/testtaskrunner_test.go
@@ -83,9 +83,6 @@ func (t *testTaskRunner) ExecuteHooks(ctx context.Context, events []v1.Hook_Cond
 }
 
 func (t *testTaskRunner) QueryOperations(q oplog.Query, fn func(*v1.Operation) error) error {
-	if q.InstanceID == nil {
-		q.SetInstanceID(t.InstanceID())
-	}
 	return t.oplog.Query(q, fn)
 }
 


### PR DESCRIPTION
If a repo only receives snapshots created outside backrest, the scheduled forget never becomes due. My setup: rest-server on the backrest machine, laptop pushes restic backups to it, backrest handles retention with a repo-level forget policy.

External snapshots never produce an `OperationBackup`. The indexer records them as `OperationIndexSnapshot`. The `foundBackup` scan in `Next` only looked at `OperationBackup`, so an external-only repo always looks idle. With `CLOCK_LAST_RUN_TIME` that resets the schedule base to now when it sees no backups, so restarts and config changes kept pushing the run out.

Fix: count a live (`Forgot == false`) `OperationIndexSnapshot` as activity. Index ops are timestamped from the snapshot's own time, so they slot into the scan the same way backup ops do.

Also dropped a default instance-ID filter that `testTaskRunner.QueryOperations` was adding but prod `taskRunnerImpl` doesn't. It would have hidden unassociated ops from the regression test, since `Next`'s query is deliberately instance-unscoped. Neutral for existing tests, they all seed ops with the config instance ID.

Tests: four scheduled-forget cases in `TestScheduling`. The indexed-snapshot case fails on main.
