### PR TITLE
fix: rm deprecated import github.com/ncruces/go-sqlite3/embed

### DIFF
--- a/internal/kvstore/sqlitekvstore.go
+++ b/internal/kvstore/sqlitekvstore.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	_ "github.com/ncruces/go-sqlite3/driver"
-	_ "github.com/ncruces/go-sqlite3/embed"
 )
 
 var ErrNotExist = errors.New("key does not exist")

--- a/internal/logstore/logstore.go
+++ b/internal/logstore/logstore.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 	_ "github.com/ncruces/go-sqlite3/driver"
-	_ "github.com/ncruces/go-sqlite3/embed"
 	"go.uber.org/zap"
 )
 

--- a/internal/oplog/sqlitestore/sqlitestore.go
+++ b/internal/oplog/sqlitestore/sqlitestore.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/gofrs/flock"
 	_ "github.com/ncruces/go-sqlite3/driver"
-	_ "github.com/ncruces/go-sqlite3/embed"
 	"github.com/ncruces/go-sqlite3/vfs"
 	"github.com/ncruces/go-sqlite3/vfs/memdb"
 	_ "github.com/ncruces/go-sqlite3/vfs/memdb"


### PR DESCRIPTION
I ran and it said

```console
$ backrest -version
If you're reading this, you're unnecessarily importing github.com/ncruces/go-sqlite3/embed.
backrest version: 1.14.1, commit: 875c9cb51e626a75276a64da42c6a9ec0695010a
```
