### PR TITLE
fix: exit after printing version

### DIFF
--- a/cmd/backrest/backrest.go
+++ b/cmd/backrest/backrest.go
@@ -58,7 +58,7 @@ func runApp() {
 	flag.Parse()
 	if *printVersion {
 		fmt.Printf("backrest version: %s, commit: %s\n", version, commit)
-		return
+		os.Exit(0)
 	}
 	installLoggers(version, commit)
 


### PR DESCRIPTION
In tray mode `backrest -tray -version` prints version and app stays open in the tray.

With this pr it will exit properly.
