### PR TITLE
fix: quit tray on graceful shutdown

### DIFF
--- a/cmd/backrest/tray.go
+++ b/cmd/backrest/tray.go
@@ -16,7 +16,10 @@ func startTray() {
 	status := newTrayStatus()
 	// Observe oplog status in-process so the icon can reflect backup state.
 	onOpLogReady = status.attach
-	go runApp()
+	go func() {
+		runApp()
+		systray.Quit()
+	}()
 	systray.Run(func() { onReady(status) }, func() {})
 }
 


### PR DESCRIPTION
Currently `ctrl+c` when backrest is run via `-tray` doesn't quit the tray.
