### PR TITLE
fix: preserve indexed snapshots in dashboard history

### DIFF
--- a/internal/api/summarydashboard.go
+++ b/internal/api/summarydashboard.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"slices"
 	"time"
 
@@ -47,22 +48,34 @@ func (s *BackrestHandler) GetSummaryDashboard(ctx context.Context, req *connect.
 	for _, plan := range cfg.Plans {
 		planAccs[plan.Id] = newSummaryAcc(cutoffMidnight)
 	}
-	// Walk every operation for this instance, newest to oldest, dispatching each
-	// backup to its plan's and its repo's accumulator.
+	// Walk every operation for this instance, newest to oldest, dispatching backup
+	// and indexed-snapshot evidence to its plan's and its repo's accumulator.
 	if err := s.oplog.Query(oplog.Query{}.SetInstanceID(cfg.Instance).SetReversed(true), func(op *v1.Operation) error {
-		backupOp := op.GetOperationBackup()
-		if backupOp == nil {
-			return nil
+		if backupOp := op.GetOperationBackup(); backupOp != nil {
+			if acc, ok := planAccs[op.PlanId]; ok {
+				acc.observeBackup(op, backupOp)
+			}
+			if acc, ok := repoAccs[op.RepoGuid]; ok {
+				acc.observeBackup(op, backupOp)
+			}
 		}
-		if acc, ok := planAccs[op.PlanId]; ok {
-			acc.observe(op, backupOp)
-		}
-		if acc, ok := repoAccs[op.RepoGuid]; ok {
-			acc.observe(op, backupOp)
+		if indexOp := op.GetOperationIndexSnapshot(); indexOp != nil {
+			if acc, ok := planAccs[op.PlanId]; ok {
+				acc.observeIndexedSnapshot(op, indexOp)
+			}
+			if acc, ok := repoAccs[op.RepoGuid]; ok {
+				acc.observeIndexedSnapshot(op, indexOp)
+			}
 		}
 		return nil
 	}); err != nil {
 		return nil, fmt.Errorf("failed to query operations: %w", err)
+	}
+	for _, acc := range repoAccs {
+		acc.applyIndexedSnapshotFallbacks()
+	}
+	for _, acc := range planAccs {
+		acc.applyIndexedSnapshotFallbacks()
 	}
 
 	response := &v1.SummaryDashboardResponse{
@@ -121,6 +134,14 @@ type summaryDayAcc struct {
 	statusCounts map[v1.OperationStatus]int64
 }
 
+type indexedSnapshotEvidence struct {
+	snapshotID string
+	flowID     int64
+	startTime  time.Time
+	endTimeMs  int64
+	summary    *v1.SnapshotSummary
+}
+
 // summaryAcc accumulates the backup operations for one plan or repo, observed
 // newest to oldest, into a dashboard summary.
 type summaryAcc struct {
@@ -147,22 +168,56 @@ type summaryAcc struct {
 	// reset the staleness clock, plus the most recent OK backup before the window.
 	okBackupDates            []time.Time
 	lastOkBackupBeforeWindow time.Time
+
+	// The oplog is observed newest-first. A snapshot starts just after its backup
+	// operation, so retaining only the next unmatched snapshot for each plan is
+	// enough to identify a missing backup without keeping every snapshot in memory.
+	pendingIndexedByPlan map[string]indexedSnapshotEvidence
 }
 
 func newSummaryAcc(cutoffMidnight time.Time) *summaryAcc {
 	return &summaryAcc{
-		cutoffMidnight: cutoffMidnight,
-		backupChart:    &v1.SummaryDashboardResponse_BackupChart{},
-		perDay:         make(map[int64]*summaryDayAcc),
+		cutoffMidnight:       cutoffMidnight,
+		backupChart:          &v1.SummaryDashboardResponse_BackupChart{},
+		perDay:               make(map[int64]*summaryDayAcc),
+		pendingIndexedByPlan: make(map[string]indexedSnapshotEvidence),
 	}
 }
 
-func (a *summaryAcc) observe(op *v1.Operation, backupOp *v1.OperationBackup) {
+func (a *summaryAcc) observeBackup(op *v1.Operation, backupOp *v1.OperationBackup) {
+	if op.GetStatus() == v1.OperationStatus_STATUS_PENDING {
+		a.nextBackupTime = op.UnixTimeStartMs
+		return
+	}
+	if evidence, ok := a.pendingIndexedByPlan[op.PlanId]; ok {
+		delete(a.pendingIndexedByPlan, op.PlanId)
+		if evidence.snapshotID != op.SnapshotId {
+			a.applyIndexedSnapshotFallback(evidence)
+		}
+	}
+
 	startTime := time.UnixMilli(op.UnixTimeStartMs)
-	opMidnight := localMidnight(startTime)
 	// Dry runs don't reset the staleness clock, matching the scheduler's view.
 	isOkBackup := (op.Status == v1.OperationStatus_STATUS_SUCCESS ||
 		op.Status == v1.OperationStatus_STATUS_WARNING) && !backupOp.DryRun
+
+	a.observeCompletedBackup(startTime, op.UnixTimeEndMs, op.FlowId, op.Status, isOkBackup, backupOp.GetLastStatus().GetSummary())
+}
+
+type backupSummary interface {
+	GetDataAdded() int64
+	GetTotalBytesProcessed() int64
+}
+
+func (a *summaryAcc) observeCompletedBackup(
+	startTime time.Time,
+	endTimeMs int64,
+	flowID int64,
+	status v1.OperationStatus,
+	isOkBackup bool,
+	summary backupSummary,
+) {
+	opMidnight := localMidnight(startTime)
 
 	// Backups older than the window only contribute the staleness anchor; walking
 	// newest-first, the first OK backup seen here is the most recent.
@@ -173,13 +228,9 @@ func (a *summaryAcc) observe(op *v1.Operation, backupOp *v1.OperationBackup) {
 		}
 		return
 	}
-	if op.GetStatus() == v1.OperationStatus_STATUS_PENDING {
-		a.nextBackupTime = op.UnixTimeStartMs
-		return
-	}
 	a.backupsExamined++
 
-	switch op.Status {
+	switch status {
 	case v1.OperationStatus_STATUS_SUCCESS:
 		a.backupsSuccess30++
 	case v1.OperationStatus_STATUS_ERROR:
@@ -192,15 +243,14 @@ func (a *summaryAcc) observe(op *v1.Operation, backupOp *v1.OperationBackup) {
 		a.okBackupDates = append(a.okBackupDates, startTime)
 	}
 
-	summary := backupOp.GetLastStatus().GetSummary()
 	if summary != nil {
-		a.bytesScanned30 += summary.TotalBytesProcessed
-		a.bytesAdded30 += summary.DataAdded
+		a.bytesScanned30 += summary.GetTotalBytesProcessed()
+		a.bytesAdded30 += summary.GetDataAdded()
 	}
 
 	// protected_bytes: the most recent (first seen) good backup's total size.
 	if a.protectedBytes == 0 && summary != nil && isOkBackup {
-		a.protectedBytes = summary.TotalBytesProcessed
+		a.protectedBytes = summary.GetTotalBytesProcessed()
 	}
 
 	// Update the per-day aggregate for this backup's day.
@@ -210,27 +260,69 @@ func (a *summaryAcc) observe(op *v1.Operation, backupOp *v1.OperationBackup) {
 		acc = &summaryDayAcc{statusCounts: make(map[v1.OperationStatus]int64)}
 		a.perDay[dayMs] = acc
 	}
-	acc.statusCounts[op.Status]++
+	acc.statusCounts[status]++
 	if summary != nil {
-		acc.bytesAdded += summary.DataAdded
-		acc.bytesScanned += summary.TotalBytesProcessed
+		acc.bytesAdded += summary.GetDataAdded()
+		acc.bytesScanned += summary.GetTotalBytesProcessed()
 	}
 	if a.oldestDay.IsZero() || opMidnight.Before(a.oldestDay) {
 		a.oldestDay = opMidnight
 	}
 
 	if len(a.backupChart.TimestampMs) < summaryChartBackups {
-		duration := op.UnixTimeEndMs - op.UnixTimeStartMs
+		duration := endTimeMs - startTime.UnixMilli()
 		if duration <= 1000 {
 			duration = 1000
 		}
 
-		a.backupChart.FlowId = append(a.backupChart.FlowId, op.FlowId)
-		a.backupChart.TimestampMs = append(a.backupChart.TimestampMs, op.UnixTimeStartMs)
+		a.backupChart.FlowId = append(a.backupChart.FlowId, flowID)
+		a.backupChart.TimestampMs = append(a.backupChart.TimestampMs, startTime.UnixMilli())
 		a.backupChart.DurationMs = append(a.backupChart.DurationMs, duration)
-		a.backupChart.Status = append(a.backupChart.Status, op.Status)
+		a.backupChart.Status = append(a.backupChart.Status, status)
 		a.backupChart.BytesAdded = append(a.backupChart.BytesAdded, summary.GetDataAdded())
 	}
+}
+
+func (a *summaryAcc) observeIndexedSnapshot(op *v1.Operation, indexOp *v1.OperationIndexSnapshot) {
+	if indexOp.Forgot {
+		return
+	}
+	snapshot := indexOp.Snapshot
+	if snapshot == nil || snapshot.Id == "" {
+		return
+	}
+	evidence := indexedSnapshotEvidence{
+		snapshotID: snapshot.Id,
+		flowID:     op.FlowId,
+		startTime:  time.UnixMilli(snapshot.UnixTimeMs),
+		endTimeMs:  op.UnixTimeEndMs,
+		summary:    snapshot.Summary,
+	}
+	if previous, ok := a.pendingIndexedByPlan[op.PlanId]; ok && previous.snapshotID != snapshot.Id {
+		a.applyIndexedSnapshotFallback(previous)
+	}
+	a.pendingIndexedByPlan[op.PlanId] = evidence
+}
+
+func (a *summaryAcc) applyIndexedSnapshotFallbacks() {
+	evidenceByTime := slices.SortedFunc(maps.Values(a.pendingIndexedByPlan), func(x, y indexedSnapshotEvidence) int {
+		return y.startTime.Compare(x.startTime)
+	})
+	clear(a.pendingIndexedByPlan)
+	for _, evidence := range evidenceByTime {
+		a.applyIndexedSnapshotFallback(evidence)
+	}
+}
+
+func (a *summaryAcc) applyIndexedSnapshotFallback(evidence indexedSnapshotEvidence) {
+	a.observeCompletedBackup(
+		evidence.startTime,
+		evidence.endTimeMs,
+		evidence.flowID,
+		v1.OperationStatus_STATUS_SUCCESS,
+		true,
+		evidence.summary,
+	)
 }
 
 // finalize builds the summary proto. allowedStaleness > 0 enables overdue

--- a/internal/api/summarydashboard_test.go
+++ b/internal/api/summarydashboard_test.go
@@ -1,9 +1,142 @@
 package api
 
 import (
+	"reflect"
 	"testing"
 	"time"
+
+	v1 "github.com/garethgeorge/backrest/gen/go/v1"
 )
+
+func TestSummaryIndexedSnapshotFallback(t *testing.T) {
+	day := func(n int) time.Time {
+		return time.Date(2026, 7, 16+n, 0, 0, 0, 0, time.Local)
+	}
+	atNoon := func(n int) time.Time { return day(n).Add(12 * time.Hour) }
+
+	acc := newSummaryAcc(day(0))
+	acc.observeIndexedSnapshot(&v1.Operation{
+		PlanId:        "test-plan",
+		FlowId:        101,
+		UnixTimeEndMs: atNoon(1).Add(time.Minute).UnixMilli(),
+	}, &v1.OperationIndexSnapshot{
+		Snapshot: &v1.ResticSnapshot{
+			Id:         "existing-backup",
+			UnixTimeMs: atNoon(1).UnixMilli(),
+		},
+	})
+	acc.observeBackup(&v1.Operation{
+		PlanId:          "test-plan",
+		FlowId:          101,
+		SnapshotId:      "existing-backup",
+		Status:          v1.OperationStatus_STATUS_SUCCESS,
+		UnixTimeStartMs: atNoon(1).UnixMilli(),
+		UnixTimeEndMs:   atNoon(1).Add(time.Minute).UnixMilli(),
+	}, &v1.OperationBackup{})
+	acc.observeIndexedSnapshot(&v1.Operation{
+		PlanId:        "test-plan",
+		FlowId:        100,
+		UnixTimeEndMs: atNoon(0).Add(2 * time.Minute).UnixMilli(),
+	}, &v1.OperationIndexSnapshot{
+		Snapshot: &v1.ResticSnapshot{
+			Id:         "fallback-snapshot",
+			UnixTimeMs: atNoon(0).UnixMilli(),
+			Summary: &v1.SnapshotSummary{
+				DataAdded:           25,
+				TotalBytesProcessed: 250,
+			},
+		},
+	})
+	acc.observeIndexedSnapshot(&v1.Operation{
+		PlanId: "test-plan",
+	}, &v1.OperationIndexSnapshot{
+		Forgot: true,
+		Snapshot: &v1.ResticSnapshot{
+			Id:         "forgotten-snapshot",
+			UnixTimeMs: atNoon(2).UnixMilli(),
+		},
+	})
+	acc.applyIndexedSnapshotFallbacks()
+
+	summary := acc.finalize("test", atNoon(2), 0)
+	history := summary.HistoryLast_30Days
+	statusCount := func(dayIndex int, status v1.OperationStatus) int64 {
+		for _, sc := range history[dayIndex].StatusCounts {
+			if sc.Status == status {
+				return sc.Count
+			}
+		}
+		return 0
+	}
+
+	if got := statusCount(0, v1.OperationStatus_STATUS_SUCCESS); got != 1 {
+		t.Errorf("fallback day success count = %d, want 1", got)
+	}
+	if history[0].BytesAdded != 25 || history[0].BytesScanned != 250 {
+		t.Errorf("fallback day bytes = (%d, %d), want (25, 250)",
+			history[0].BytesAdded, history[0].BytesScanned)
+	}
+	if got := statusCount(1, v1.OperationStatus_STATUS_SUCCESS); got != 1 {
+		t.Errorf("deduplicated day success count = %d, want 1", got)
+	}
+	if got := statusCount(2, v1.OperationStatus_STATUS_SUCCESS); got != 0 {
+		t.Errorf("forgotten snapshot success count = %d, want 0", got)
+	}
+	if summary.BackupsSuccessLast_30Days != 2 {
+		t.Errorf("success count = %d, want 2", summary.BackupsSuccessLast_30Days)
+	}
+	if summary.BytesAddedLast_30Days != 25 || summary.BytesScannedLast_30Days != 250 {
+		t.Errorf("summary bytes = (%d, %d), want (25, 250)",
+			summary.BytesAddedLast_30Days, summary.BytesScannedLast_30Days)
+	}
+	if summary.BytesAddedAvg != 12 || summary.BytesScannedAvg != 125 {
+		t.Errorf("average bytes = (%d, %d), want (12, 125)",
+			summary.BytesAddedAvg, summary.BytesScannedAvg)
+	}
+	if summary.ProtectedBytes != 250 {
+		t.Errorf("protected bytes = %d, want 250", summary.ProtectedBytes)
+	}
+	if len(summary.RecentBackups.Status) != 2 ||
+		summary.RecentBackups.Status[1] != v1.OperationStatus_STATUS_SUCCESS ||
+		summary.RecentBackups.FlowId[1] != 100 ||
+		summary.RecentBackups.BytesAdded[1] != 25 {
+		t.Errorf("fallback chart entry = %+v, want successful flow 100 with 25 bytes added",
+			summary.RecentBackups)
+	}
+
+	again := acc.finalize("test", atNoon(2), 0)
+	if !reflect.DeepEqual(summary, again) {
+		t.Error("finalize mutated the accumulator")
+	}
+}
+
+func TestSummaryIndexedSnapshotFallbacksRemainNewestFirst(t *testing.T) {
+	day := func(n int) time.Time {
+		return time.Date(2026, 7, 16+n, 12, 0, 0, 0, time.Local)
+	}
+	acc := newSummaryAcc(localMidnight(day(0)))
+
+	acc.observeIndexedSnapshot(&v1.Operation{
+		PlanId:        "newer-plan",
+		FlowId:        2,
+		UnixTimeEndMs: day(2).Add(time.Minute).UnixMilli(),
+	}, &v1.OperationIndexSnapshot{
+		Snapshot: &v1.ResticSnapshot{Id: "newer", UnixTimeMs: day(2).UnixMilli()},
+	})
+	acc.observeIndexedSnapshot(&v1.Operation{
+		PlanId:        "older-plan",
+		FlowId:        1,
+		UnixTimeEndMs: day(1).Add(time.Minute).UnixMilli(),
+	}, &v1.OperationIndexSnapshot{
+		Snapshot: &v1.ResticSnapshot{Id: "older", UnixTimeMs: day(1).UnixMilli()},
+	})
+	acc.applyIndexedSnapshotFallbacks()
+
+	chart := acc.finalize("test", day(2), 0).RecentBackups
+	if !reflect.DeepEqual(chart.FlowId, []int64{2, 1}) {
+		t.Errorf("fallback chart flow order = %v, want [2 1]", chart.FlowId)
+	}
+}
 
 func TestSummaryOverdueFlags(t *testing.T) {
 	// Fixed UTC reference: "today" is Jun 30 2026; the window is the prior 9 days.


### PR DESCRIPTION
Fixes #1307.

## Summary
- use live indexed snapshots as fallback evidence for dashboard history when the matching backup operation is no longer present
- deduplicate fallback snapshots against backup operations by snapshot ID
- exclude forgotten snapshots while preserving per-day byte details and overdue tracking

## Tests
- `go test ./internal/api -count=1`
- `go test ./internal/orchestrator/tasks -count=1`
- `go vet ./internal/api`
- `go test ./... -count=1` (with the CI-style fake `webui/dist/index.html.gz` embed)