### PR TITLE
Update index.md - Removed obsolete attribute for docker

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -71,7 +71,6 @@ mkdir backrest && tar -xzvf backrest_Darwin_arm64.tar.gz -C backrest
 cd backrest && ./install.sh
 ```
 ```yaml [docker-compose]
-version: "3.8"
 services:
   backrest:
     image: ghcr.io/garethgeorge/backrest:latest


### PR DESCRIPTION
The attribute 'version' is obsolete, removed it.