### PR TITLE
Strip surrounding quotes from repo env var values

### DIFF
--- a/internal/orchestrator/repo/env.go
+++ b/internal/orchestrator/repo/env.go
@@ -3,6 +3,7 @@ package repo
 import (
 	"os"
 	"regexp"
+	"strings"
 )
 
 var (
@@ -15,4 +16,29 @@ func ExpandEnv(s string) string {
 		e, _ := os.LookupEnv(match[2 : len(match)-1])
 		return e
 	})
+}
+
+// StripEnvValueQuotes removes a single matching pair of surrounding quotes
+// (either " or ') from the VALUE portion of a KEY=VALUE string, if present.
+//
+// This exists because Go's os/exec sets process environment variables
+// verbatim from the "KEY=VALUE" strings it is given -- unlike a shell, it
+// does not strip quotes from the value. Users commonly write env vars in the
+// KEY="VALUE" form out of habit (e.g. copying from a .env file or shell
+// script), which would otherwise leave literal quote characters embedded in
+// the value passed to restic, breaking things like base64-encoded secrets.
+func StripEnvValueQuotes(kv string) string {
+	idx := strings.Index(kv, "=")
+	if idx == -1 {
+		return kv
+	}
+	key := kv[:idx]
+	value := kv[idx+1:]
+	if len(value) >= 2 {
+		first, last := value[0], value[len(value)-1]
+		if (first == '"' && last == '"') || (first == '\'' && last == '\'') {
+			value = value[1 : len(value)-1]
+		}
+	}
+	return key + "=" + value
 }

--- a/internal/orchestrator/repo/env_test.go
+++ b/internal/orchestrator/repo/env_test.go
@@ -1,0 +1,32 @@
+package repo
+
+import "testing"
+
+func TestStripEnvValueQuotes(t *testing.T) {
+	tcs := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"no quotes", "KEY=value", "KEY=value"},
+		{"double quotes", `KEY="value"`, "KEY=value"},
+		{"single quotes", "KEY='value'", "KEY=value"},
+		{"empty double quotes", `KEY=""`, "KEY="},
+		{"empty single quotes", "KEY=''", "KEY="},
+		{"no value", "KEY=", "KEY="},
+		{"mismatched quotes left untouched", `KEY="value'`, `KEY="value'`},
+		{"quote only inside value untouched", `KEY=va"lu"e`, `KEY=va"lu"e`},
+		{"no equals sign untouched", "NOEQUALSSIGN", "NOEQUALSSIGN"},
+		{"value with embedded equals", `KEY="a=b"`, "KEY=a=b"},
+		{"double quotes around base64-like value", `AZURE_ACCOUNT_KEY="abc123=="`, "AZURE_ACCOUNT_KEY=abc123=="},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			got := StripEnvValueQuotes(tc.in)
+			if got != tc.want {
+				t.Errorf("StripEnvValueQuotes(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/orchestrator/repo/repo.go
+++ b/internal/orchestrator/repo/repo.go
@@ -55,7 +55,7 @@ func NewRepoOrchestrator(config *v1.Config, repoConfig *v1.Repo, resticPath stri
 
 	if env := repoConfig.GetEnv(); len(env) != 0 {
 		for _, e := range env {
-			opts = append(opts, restic.WithEnv(ExpandEnv(e)))
+			opts = append(opts, restic.WithEnv(ExpandEnv(StripEnvValueQuotes(e))))
 		}
 	}
 


### PR DESCRIPTION
## Problem

When a repo is configured with an env var value wrapped in quotes, e.g.:

```
AZURE_ACCOUNT_KEY="abc123=="
```

restic operations fail with an error like:

```
[unknown] command "/bin/restic cat config -o sftp.args=-oBatchMode=yes" failed: exit status 1
Fatal: unable to open repository at azure: restic-backups:/backupnas: NewSharedKeyCredential: decode account key: illegal base64 data at input byte 0
```

### Root cause

Backrest passes each configured KEY=VALUE env var entry directly into Go's exec.Cmd.Env. Unlike a shell, Go performs no quote parsing on these strings -- the value is taken completely verbatim, including any literal double/single quote characters. Users who quote values out of habit (e.g. copying from a .env file or shell script) end up with the quote characters embedded in the actual environment variable value, which breaks strict-format values like base64-encoded secrets.

## Fix

Added `StripEnvValueQuotes` in `internal/orchestrator/repo/env.go`, which strips a single matching pair of surrounding quotes (double or single) from the value portion of a KEY=VALUE string, applied before the value is expanded (${VAR} substitution) and passed to restic. Mismatched or embedded quotes are left untouched.

## Testing

- Added `internal/orchestrator/repo/env_test.go` covering quoted/unquoted/mismatched/embedded-equals cases.
- `go test ./internal/orchestrator/repo/... ./internal/config/...` passes.
