### PR TITLE
Add operation type filter dropdown to repo and plan tree/list views

### DIFF
--- a/webui/src/features/operations/OperationFilter.tsx
+++ b/webui/src/features/operations/OperationFilter.tsx
@@ -1,0 +1,99 @@
+import React from "react";
+import { Button } from "../../components/ui/button";
+import {
+  MenuRoot,
+  MenuTrigger,
+  MenuContent,
+  MenuItem,
+  MenuSeparator,
+} from "../../components/ui/menu";
+import { Flex, Box } from "@chakra-ui/react";
+import { FiFilter, FiCheckSquare, FiSquare } from "react-icons/fi";
+import {
+  DisplayType,
+  displayTypeToString,
+} from "../../api/flowDisplayAggregator";
+import { OperationIcon } from "./OperationIcon";
+import { OperationStatus } from "../../../gen/ts/v1/operations_pb";
+
+export interface OperationFilterProps {
+  types: DisplayType[];
+  activeTypes: Set<DisplayType>;
+  onToggle: (type: DisplayType) => void;
+  onSelectAll: () => void;
+  onSelectNone: () => void;
+}
+
+export const OperationFilter = ({
+  types,
+  activeTypes,
+  onToggle,
+  onSelectAll,
+  onSelectNone,
+}: OperationFilterProps) => {
+  return (
+    <MenuRoot>
+      <MenuTrigger asChild>
+        <Button size="xs" variant="outline" colorPalette="blue">
+          <Flex align="center" gap={1}>
+            <FiFilter />
+            <span style={{ fontSize: "0.75rem" }}>Filter</span>
+            <span style={{ fontSize: "0.7rem", opacity: 0.8 }}>
+              ({activeTypes.size}/{types.length})
+            </span>
+          </Flex>
+        </Button>
+      </MenuTrigger>
+      <MenuContent minW="220px">
+        <MenuItem value="all" closeOnSelect={false} onClick={onSelectAll}>
+          <Flex align="center" gap={2} width="100%">
+            <Box flex="1" fontSize="sm">
+              All
+            </Box>
+            {activeTypes.size === types.length ? (
+              <FiCheckSquare size={14} />
+            ) : (
+              <FiSquare size={14} />
+            )}
+          </Flex>
+        </MenuItem>
+        <MenuItem value="none" closeOnSelect={false} onClick={onSelectNone}>
+          <Flex align="center" gap={2} width="100%">
+            <Box flex="1" fontSize="sm">
+              None
+            </Box>
+            {activeTypes.size === 0 ? (
+              <FiCheckSquare size={14} />
+            ) : (
+              <FiSquare size={14} />
+            )}
+          </Flex>
+        </MenuItem>
+        <MenuSeparator />
+        {types.map((type) => (
+          <MenuItem
+            key={type}
+            value={String(type)}
+            closeOnSelect={false}
+            onClick={() => onToggle(type)}
+          >
+            <Flex align="center" gap={2} width="100%">
+              <OperationIcon
+                type={type}
+                status={OperationStatus.STATUS_UNKNOWN}
+              />
+              <Box flex="1" fontSize="sm">
+                {displayTypeToString(type)}
+              </Box>
+              {activeTypes.has(type) ? (
+                <FiCheckSquare size={14} />
+              ) : (
+                <FiSquare size={14} />
+              )}
+            </Flex>
+          </MenuItem>
+        ))}
+      </MenuContent>
+    </MenuRoot>
+  );
+};

--- a/webui/src/features/operations/OperationListView.tsx
+++ b/webui/src/features/operations/OperationListView.tsx
@@ -65,7 +65,11 @@ export const OperationListView = ({
         setLoading(false);
       },
     );
-  }, [req ? toJsonString(GetOperationsRequestSchema, req) : ""]);
+  }, [req ? toJsonString(GetOperationsRequestSchema, req) : "", filter]);
+
+  useEffect(() => {
+    setPage(1);
+  }, [filter, req ? toJsonString(GetOperationsRequestSchema, req) : ""]);
 
   const hookExecutionsForOperation: Map<bigint, Operation[]> = new Map();
   let operationsForDisplay: Operation[] = [];

--- a/webui/src/features/operations/OperationTreeView.tsx
+++ b/webui/src/features/operations/OperationTreeView.tsx
@@ -88,9 +88,11 @@ interface OpTreeNode {
 export const OperationTreeView = ({
   req,
   isPlanView,
+  filter,
 }: React.PropsWithoutRef<{
   req: GetOperationsRequest;
   isPlanView?: boolean;
+  filter?: (op: FlowDisplayInfo) => boolean;
 }>) => {
   const config = useConfig()[0];
   const setScreenWidth = useState(window.innerWidth)[1];
@@ -185,7 +187,27 @@ export const OperationTreeView = ({
 
   const useMobileLayout = isMobile();
 
-  const backupsByInstance = groupBy(backups, (b) => {
+  const visibleBackups = filter ? backups.filter(filter) : backups;
+
+  if (visibleBackups.length === 0) {
+    return (
+      <EmptyState.Root>
+        <EmptyState.Content>
+          <EmptyState.Indicator>
+            <LuInfo />
+          </EmptyState.Indicator>
+          <VStack textAlign="center">
+            <EmptyState.Title>{m.operation_tree_view_no_operations_found()}</EmptyState.Title>
+            <EmptyState.Description>
+              {m.operation_tree_view_there_are_no_operations_to_display()}
+            </EmptyState.Description>
+          </VStack>
+        </EmptyState.Content>
+      </EmptyState.Root>
+    );
+  }
+
+  const backupsByInstance = groupBy(visibleBackups, (b) => {
     return b.instanceID;
   });
 

--- a/webui/src/features/plans/PlanView.tsx
+++ b/webui/src/features/plans/PlanView.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { Plan } from "../../../gen/ts/v1/config_pb";
 import { Button } from "../../components/ui/button";
 import { Flex, Heading, Text, Box, Group, IconButton } from "@chakra-ui/react";
@@ -33,12 +33,66 @@ import { create } from "@bufbuild/protobuf";
 import { useConfig } from "../../app/provider";
 import { OperationListView } from "../operations/OperationListView";
 import { OperationTreeView } from "../operations/OperationTreeView";
+import {
+  DisplayType,
+  FlowDisplayInfo,
+  getTypeForDisplay,
+} from "../../api/flowDisplayAggregator";
+import { Operation } from "../../../gen/ts/v1/operations_pb";
+import { OperationFilter } from "../operations/OperationFilter";
 import * as m from "../../paraglide/messages";
+
+const FILTER_TYPES = [
+  DisplayType.BACKUP,
+  DisplayType.BACKUP_DRYRUN,
+  DisplayType.SNAPSHOT,
+  DisplayType.FORGET,
+  DisplayType.PRUNE,
+  DisplayType.CHECK,
+  DisplayType.RESTORE,
+  DisplayType.STATS,
+  DisplayType.RUNHOOK,
+  DisplayType.RUNCOMMAND,
+];
 
 export const PlanView = ({ plan }: React.PropsWithChildren<{ plan: Plan }>) => {
   const [config, _] = useConfig();
   const showModal = useShowModal();
   const repo = config?.repos.find((r) => r.id === plan.repo);
+
+  const [activeTypes, setActiveTypes] = useState<Set<DisplayType>>(
+    new Set(FILTER_TYPES),
+  );
+
+  const toggleType = (type: DisplayType) => {
+    setActiveTypes((prev) => {
+      const next = new Set(prev);
+      if (next.has(type)) {
+        next.delete(type);
+      } else {
+        next.add(type);
+      }
+      return next;
+    });
+  };
+
+  const selectAll = () => {
+    setActiveTypes(new Set(FILTER_TYPES));
+  };
+
+  const selectNone = () => {
+    setActiveTypes(new Set());
+  };
+
+  const treeFilter = useCallback(
+    (flow: FlowDisplayInfo) => activeTypes.has(flow.type),
+    [activeTypes],
+  );
+
+  const listFilter = useCallback(
+    (op: Operation) => activeTypes.has(getTypeForDisplay(op)),
+    [activeTypes],
+  );
 
   const handleBackupNow = async () => {
     try {
@@ -164,6 +218,15 @@ export const PlanView = ({ plan }: React.PropsWithChildren<{ plan: Plan }>) => {
         </TabsList>
 
         <TabsContent value="tree">
+          <Box mb={2}>
+            <OperationFilter
+              types={FILTER_TYPES}
+              activeTypes={activeTypes}
+              onToggle={toggleType}
+              onSelectAll={selectAll}
+              onSelectNone={selectNone}
+            />
+          </Box>
           <OperationTreeView
             req={create(GetOperationsRequestSchema, {
               selector: {
@@ -174,13 +237,21 @@ export const PlanView = ({ plan }: React.PropsWithChildren<{ plan: Plan }>) => {
               lastN: BigInt(MAX_OPERATION_HISTORY),
             })}
             isPlanView={true}
+            filter={treeFilter}
           />
         </TabsContent>
 
         <TabsContent value="list">
-          <Heading size="md" mb={4}>
-            {m.repo_history_title()}
-          </Heading>
+          <Flex mb={4} align="center" justify="space-between" wrap="wrap">
+            <Heading size="md">{m.repo_history_title()}</Heading>
+            <OperationFilter
+              types={FILTER_TYPES}
+              activeTypes={activeTypes}
+              onToggle={toggleType}
+              onSelectAll={selectAll}
+              onSelectNone={selectNone}
+            />
+          </Flex>
           <OperationListView
             req={create(GetOperationsRequestSchema, {
               selector: {
@@ -190,6 +261,7 @@ export const PlanView = ({ plan }: React.PropsWithChildren<{ plan: Plan }>) => {
               },
               lastN: BigInt(MAX_OPERATION_HISTORY),
             })}
+            filter={listFilter}
             showDelete={true}
           />
         </TabsContent>

--- a/webui/src/features/repositories/RepoView.tsx
+++ b/webui/src/features/repositories/RepoView.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense, useContext, useEffect, useState } from "react";
+import React, { Suspense, useCallback, useContext, useEffect, useState } from "react";
 import { Repo } from "../../../gen/ts/v1/config_pb";
 import { Button } from "../../components/ui/button";
 import { Flex, Heading, Box, Group, IconButton } from "@chakra-ui/react";
@@ -37,14 +37,68 @@ import { useShowModal } from "../../components/common/ModalManager";
 import { create } from "@bufbuild/protobuf";
 import { RepoProps } from "../../state/peerStates";
 import * as m from "../../paraglide/messages";
+import {
+  DisplayType,
+  FlowDisplayInfo,
+  getTypeForDisplay,
+} from "../../api/flowDisplayAggregator";
+import { Operation } from "../../../gen/ts/v1/operations_pb";
+import { OperationFilter } from "../operations/OperationFilter";
 
 const StatsPanel = React.lazy(() => import("../dashboard/StatsPanel"));
+
+const FILTER_TYPES = [
+  DisplayType.BACKUP,
+  DisplayType.BACKUP_DRYRUN,
+  DisplayType.SNAPSHOT,
+  DisplayType.FORGET,
+  DisplayType.PRUNE,
+  DisplayType.CHECK,
+  DisplayType.RESTORE,
+  DisplayType.STATS,
+  DisplayType.RUNHOOK,
+  DisplayType.RUNCOMMAND,
+];
 
 export const RepoView = ({
   repo,
 }: React.PropsWithChildren<{ repo: RepoProps }>) => {
   const [config, _] = useConfig();
   const showModal = useShowModal();
+
+  const [activeTypes, setActiveTypes] = useState<Set<DisplayType>>(
+    new Set(FILTER_TYPES),
+  );
+
+  const toggleType = (type: DisplayType) => {
+    setActiveTypes((prev) => {
+      const next = new Set(prev);
+      if (next.has(type)) {
+        next.delete(type);
+      } else {
+        next.add(type);
+      }
+      return next;
+    });
+  };
+
+  const selectAll = () => {
+    setActiveTypes(new Set(FILTER_TYPES));
+  };
+
+  const selectNone = () => {
+    setActiveTypes(new Set());
+  };
+
+  const treeFilter = useCallback(
+    (flow: FlowDisplayInfo) => activeTypes.has(flow.type),
+    [activeTypes],
+  );
+
+  const listFilter = useCallback(
+    (op: Operation) => activeTypes.has(getTypeForDisplay(op)),
+    [activeTypes],
+  );
 
   // Task handlers
   const handleIndexNow = async () => {
@@ -208,6 +262,15 @@ export const RepoView = ({
         </TabsList>
 
         <TabsContent value="tree">
+          <Box mb={2}>
+            <OperationFilter
+              types={FILTER_TYPES}
+              activeTypes={activeTypes}
+              onToggle={toggleType}
+              onSelectAll={selectAll}
+              onSelectNone={selectNone}
+            />
+          </Box>
           <OperationTreeView
             req={create(GetOperationsRequestSchema, {
               selector: {
@@ -215,13 +278,21 @@ export const RepoView = ({
               },
               lastN: BigInt(MAX_OPERATION_HISTORY),
             })}
+            filter={treeFilter}
           />
         </TabsContent>
 
         <TabsContent value="list">
-          <Heading size="md" mb={4}>
-            {m.repo_history_title()}
-          </Heading>
+          <Flex mb={4} align="center" justify="space-between" wrap="wrap">
+            <Heading size="md">{m.repo_history_title()}</Heading>
+            <OperationFilter
+              types={FILTER_TYPES}
+              activeTypes={activeTypes}
+              onToggle={toggleType}
+              onSelectAll={selectAll}
+              onSelectNone={selectNone}
+            />
+          </Flex>
           <OperationListView
             req={create(GetOperationsRequestSchema, {
               selector: {
@@ -229,6 +300,7 @@ export const RepoView = ({
               },
               lastN: BigInt(MAX_OPERATION_HISTORY),
             })}
+            filter={listFilter}
             showPlan={true}
             showDelete={true}
           />


### PR DESCRIPTION
Adds filters to the **Tree/List View**:
<img width="322" height="694" alt="grafik" src="https://github.com/user-attachments/assets/3286649f-c5d3-4ea4-946b-3b3959458f9e" />

- Add `OperationFilter` component with a multi-select dropdown for operation types to the Tree/List View.
- Filter is shown on the Tree and List tabs of the repo and plan views.
- Wires the active type filter into `OperationTreeView` and `OperationListView`.