### PR TITLE
feat: link dashboard cards and history stips to plan/repo details and auto-select flows

### DIFF
--- a/webui/src/app/App.tsx
+++ b/webui/src/app/App.tsx
@@ -72,6 +72,7 @@ import {
   Routes,
   useNavigate,
   useParams,
+  useSearchParams,
   useLocation,
 } from "react-router";
 import { MainContentAreaTemplate } from "../components/layout/MainContentArea";
@@ -126,6 +127,7 @@ const SelectorView = React.lazy(() =>
 // Wrappers for consistent views with breadcrumbs and error handling
 const RepoViewContainer = () => {
   const { repoId } = useParams();
+  const [searchParams] = useSearchParams();
   const [config, setConfig] = useConfig();
 
   if (!config) {
@@ -175,7 +177,10 @@ const RepoViewContainer = () => {
               })()}
             </Box>
           )}
-          <RepoView repo={repo} />
+          <RepoView
+            repo={repo}
+            selectedFlowId={searchParams.get("flowId") || undefined}
+          />
         </>
       ) : (
         <EmptyState title={m.app_repo_not_found({ repoId: repoId || "" })} />
@@ -255,6 +260,7 @@ const RemotePlanViewContainer = () => {
 
 const PlanViewContainer = () => {
   const { planId } = useParams();
+  const [searchParams] = useSearchParams();
   const [config, setConfig] = useConfig();
 
   if (!config) {
@@ -272,7 +278,11 @@ const PlanViewContainer = () => {
       key={planId}
     >
       {plan ? (
-        <PlanView plan={plan} />
+        <PlanView
+          plan={plan}
+          selectedFlowId={searchParams.get("flowId") || undefined}
+          selectPending={searchParams.get("select") === "pending"}
+        />
       ) : (
         <EmptyState title={m.app_plan_not_found({ planId: planId || "" })} />
       )}

--- a/webui/src/features/dashboard/HistoryStrip.tsx
+++ b/webui/src/features/dashboard/HistoryStrip.tsx
@@ -18,7 +18,7 @@ type CellKind =
   | "err"
   | "other";
 
-interface DayCell {
+export interface DayCell {
   kind: CellKind;
   label: string; // local date label for the tooltip
   isToday: boolean;
@@ -242,7 +242,7 @@ export const HistoryStrip = ({
   onCellClick,
 }: {
   buckets: SummaryDashboardResponse_DayStatusBucket[];
-  onCellClick?: () => void;
+  onCellClick?: (cell: DayCell) => void;
 }) => {
   const cells = toCells(buckets);
 
@@ -274,7 +274,7 @@ export const HistoryStrip = ({
                 bg={style.bg}
                 opacity={style.dim ? 0.35 : 1}
                 cursor={onCellClick ? "pointer" : "default"}
-                onClick={onCellClick}
+                onClick={() => onCellClick?.(c)}
                 boxShadow={
                   c.isToday
                     ? "0 0 0 2px var(--chakra-colors-bg-canvas), 0 0 0 3.5px var(--chakra-colors-fg-muted)"

--- a/webui/src/features/dashboard/HistoryStrip.tsx
+++ b/webui/src/features/dashboard/HistoryStrip.tsx
@@ -239,8 +239,10 @@ const DayTooltip = ({ cell }: { cell: DayCell }) => {
 
 export const HistoryStrip = ({
   buckets,
+  onCellClick,
 }: {
   buckets: SummaryDashboardResponse_DayStatusBucket[];
+  onCellClick?: () => void;
 }) => {
   const cells = toCells(buckets);
 
@@ -271,10 +273,20 @@ export const HistoryStrip = ({
                 borderRadius="3px"
                 bg={style.bg}
                 opacity={style.dim ? 0.35 : 1}
-                cursor="default"
+                cursor={onCellClick ? "pointer" : "default"}
+                onClick={onCellClick}
                 boxShadow={
                   c.isToday
                     ? "0 0 0 2px var(--chakra-colors-bg-canvas), 0 0 0 3.5px var(--chakra-colors-fg-muted)"
+                    : undefined
+                }
+                _hover={
+                  onCellClick
+                    ? {
+                        outline: "2px solid",
+                        outlineColor: "fg.muted",
+                        outlineOffset: "1px",
+                      }
                     : undefined
                 }
               />

--- a/webui/src/features/dashboard/SummaryDashboard.tsx
+++ b/webui/src/features/dashboard/SummaryDashboard.tsx
@@ -390,8 +390,21 @@ const useLiveProgress = (
 
 // ─── Shared card building blocks ─────────────────────────────────────────────
 
-const CardTitle = ({ children }: { children: React.ReactNode }) => (
-  <Text fontSize="16px" fontWeight="640" letterSpacing="-0.01em">
+const CardTitle = ({
+  children,
+  onClick,
+}: {
+  children: React.ReactNode;
+  onClick?: () => void;
+}) => (
+  <Text
+    fontSize="16px"
+    fontWeight="640"
+    letterSpacing="-0.01em"
+    cursor={onClick ? "pointer" : undefined}
+    _hover={onClick ? { textDecoration: "underline" } : undefined}
+    onClick={onClick}
+  >
     {children}
   </Text>
 );
@@ -413,7 +426,13 @@ const StatusDot = ({ color, pulsing }: { color: string; pulsing?: boolean }) =>
   );
 
 // Large colored state label with a muted "X ago" beside it.
-const StatusLine = ({ status }: { status: SummaryStatus }) => (
+const StatusLine = ({
+  status,
+  onClickTime,
+}: {
+  status: SummaryStatus;
+  onClickTime?: () => void;
+}) => (
   <Flex align="baseline" gap={2} mt={4} mb={1}>
     <Text
       fontSize="20px"
@@ -424,7 +443,13 @@ const StatusLine = ({ status }: { status: SummaryStatus }) => (
       {STATE_LABEL[status.state]()}
     </Text>
     {status.latestTs > 0 && !status.running && (
-      <Text fontSize="13px" color="fg.muted">
+      <Text
+        fontSize="13px"
+        color="fg.muted"
+        cursor={onClickTime ? "pointer" : undefined}
+        _hover={onClickTime ? { textDecoration: "underline" } : undefined}
+        onClick={onClickTime}
+      >
         {agoText(status.latestTs)}
       </Text>
     )}
@@ -435,13 +460,22 @@ const StatusLine = ({ status }: { status: SummaryStatus }) => (
 const MetaItem = ({
   label,
   children,
+  onClick,
 }: {
   label: string;
   children: React.ReactNode;
+  onClick?: () => void;
 }) => (
   <Box fontSize="12.5px" color="fg.muted">
     {label}{" "}
-    <Text as="span" fontWeight="600" color="fg.default">
+    <Text
+      as="span"
+      fontWeight="600"
+      color="fg.default"
+      cursor={onClick ? "pointer" : undefined}
+      _hover={onClick ? { textDecoration: "underline" } : undefined}
+      onClick={onClick}
+    >
       {children}
     </Text>
   </Box>
@@ -454,6 +488,7 @@ const PlanCard = ({
 }: {
   summary: SummaryDashboardResponse_Summary;
 }) => {
+  const navigate = useNavigate();
   const [config] = useConfig();
   const status = summaryStatus(summary);
   const { running } = status;
@@ -474,6 +509,7 @@ const PlanCard = ({
   const nextMs = Number(summary.nextBackupTimeMs ?? 0);
   const protectedBytes = Number(summary.protectedBytes);
   const lastUploadBytes = Number(summary.recentBackups?.bytesAdded[0] ?? 0);
+  const lastFlowId = summary.recentBackups?.flowId[0]?.toString();
 
   let retLine: string | null = null;
   if (planCfg?.retention?.policy.case === "policyTimeBucketed") {
@@ -491,7 +527,11 @@ const PlanCard = ({
         {/* Title row */}
         <Flex justify="space-between" align="flex-start" gap={3}>
           <Box>
-            <CardTitle>{prettyPlanId(summary.id)}</CardTitle>
+            <CardTitle
+              onClick={() => navigate(`/plan/${summary.id}`)}
+            >
+              {prettyPlanId(summary.id)}
+            </CardTitle>
             {schedLine && (
               <Text fontSize="12.5px" color="fg.muted" mt="2px">
                 {schedLine}
@@ -503,7 +543,16 @@ const PlanCard = ({
           </Box>
         </Flex>
 
-        <StatusLine status={status} />
+        <StatusLine
+          status={status}
+          onClickTime={() =>
+            navigate(
+              lastFlowId
+                ? `/plan/${summary.id}?flowId=${lastFlowId}`
+                : `/plan/${summary.id}`,
+            )
+          }
+        />
 
         {/* Progress bar when running */}
         {running && (
@@ -527,12 +576,20 @@ const PlanCard = ({
         {!running && (
           <Flex flexWrap="wrap" gap="4px 18px" mt={3}>
             {nextMs > 0 && (
-              <MetaItem label={m.dashboard_card_next_run()}>
+              <MetaItem
+                label={m.dashboard_card_next_run()}
+                onClick={() =>
+                  navigate(`/plan/${summary.id}?select=pending`)
+                }
+              >
                 {untilText(nextMs) ?? m.dashboard_time_soon()}
               </MetaItem>
             )}
             {destLabel && (
-              <MetaItem label={m.dashboard_card_destination()}>
+              <MetaItem
+                label={m.dashboard_card_destination()}
+                onClick={() => navigate(`/repo/${destLabel}`)}
+              >
                 {destLabel}
               </MetaItem>
             )}
@@ -577,7 +634,9 @@ const RepoCard = ({
 }: {
   summary: SummaryDashboardResponse_Summary;
 }) => {
+  const navigate = useNavigate();
   const status = summaryStatus(summary);
+  const lastFlowId = summary.recentBackups?.flowId[0]?.toString();
   const protectedBytes = Number(summary.protectedBytes);
   const bytesAdded30d = Number(summary.bytesAddedLast30days);
 
@@ -585,13 +644,24 @@ const RepoCard = ({
     <Card.Root borderRadius="2xl" shadow="sm">
       <Card.Body px={5} py={5}>
         <Flex justify="space-between" align="flex-start" gap={3}>
-          <CardTitle>{summary.id}</CardTitle>
+          <CardTitle onClick={() => navigate(`/repo/${summary.id}`)}>
+            {summary.id}
+          </CardTitle>
           <Box mt="6px" flexShrink={0}>
             <StatusDot color={status.color} />
           </Box>
         </Flex>
 
-        <StatusLine status={status} />
+        <StatusLine
+          status={status}
+          onClickTime={() =>
+            navigate(
+              lastFlowId
+                ? `/repo/${summary.id}?flowId=${lastFlowId}`
+                : `/repo/${summary.id}`,
+            )
+          }
+        />
 
         <Flex flexWrap="wrap" gap="4px 18px" mt={3}>
           <Box fontSize="12.5px" color="fg.muted">

--- a/webui/src/features/dashboard/SummaryDashboard.tsx
+++ b/webui/src/features/dashboard/SummaryDashboard.tsx
@@ -21,8 +21,10 @@ import {
   GetOperationsRequestSchema,
   OpSelectorSchema,
   SummaryDashboardResponse,
+  SummaryDashboardResponse_BackupChart,
   SummaryDashboardResponse_Summary,
 } from "../../../gen/ts/v1/service_pb";
+import { DayCell } from "./HistoryStrip";
 import { PeerState } from "../../../gen/ts/v1sync/syncservice_pb";
 import { create } from "@bufbuild/protobuf";
 import { backrestService } from "../../api/client";
@@ -187,6 +189,24 @@ function summaryStatus(
     latestStatus === OperationStatus.STATUS_PENDING;
   const state = planState(latestStatus, running);
   return { latestTs, running, state, color: STATE_COLORS[state] };
+}
+
+const DAY_MS = 86_400_000;
+
+function flowIdForDay(
+  chart: SummaryDashboardResponse_BackupChart | undefined,
+  dayTimestampMs: bigint,
+): bigint | undefined {
+  if (!chart || dayTimestampMs === 0n) return undefined;
+  const start = dayTimestampMs;
+  const end = start + BigInt(DAY_MS);
+  for (let i = 0; i < chart.flowId.length; i++) {
+    const ts = chart.timestampMs[i];
+    if (ts >= start && ts < end) {
+      return chart.flowId[i];
+    }
+  }
+  return undefined;
 }
 
 // ─── Progress bar (animated shimmer) ─────────────────────────────────────────
@@ -609,13 +629,19 @@ const PlanCard = ({
         {/* 30-day history strip */}
         <HistoryStrip
           buckets={summary.historyLast30days}
-          onCellClick={() =>
+          onCellClick={(cell: DayCell) => {
+            const flowId =
+              cell.bucket &&
+              flowIdForDay(
+                summary.recentBackups,
+                cell.bucket.timestampMs,
+              )?.toString();
             navigate(
-              lastFlowId
-                ? `/plan/${summary.id}?flowId=${lastFlowId}`
+              flowId
+                ? `/plan/${summary.id}?flowId=${flowId}`
                 : `/plan/${summary.id}`,
-            )
-          }
+            );
+          }}
         />
 
         {/* Retention footer */}
@@ -700,18 +726,24 @@ const RepoCard = ({
               {formatBytes(bytesAdded30d)}
             </MetaItem>
           )}
-           
-              lastFlowId
-                ? `/repo/${summary.id}?flowId=${lastFlowId}
-                : `,
-            
-          
         </Flex>
 
         {/* 30-day history strip */}
         <HistoryStrip
           buckets={summary.historyLast30days}
-          onCellClick={() => navigate(`/repo/${summary.id}`)}
+          onCellClick={(cell: DayCell) => {
+            const flowId =
+              cell.bucket &&
+              flowIdForDay(
+                summary.recentBackups,
+                cell.bucket.timestampMs,
+              )?.toString();
+            navigate(
+              flowId
+                ? `/repo/${summary.id}?flowId=${flowId}`
+                : `/repo/${summary.id}`,
+            );
+          }}
         />
       </Card.Body>
     </Card.Root>

--- a/webui/src/features/dashboard/SummaryDashboard.tsx
+++ b/webui/src/features/dashboard/SummaryDashboard.tsx
@@ -607,7 +607,16 @@ const PlanCard = ({
         )}
 
         {/* 30-day history strip */}
-        <HistoryStrip buckets={summary.historyLast30days} />
+        <HistoryStrip
+          buckets={summary.historyLast30days}
+          onCellClick={() =>
+            navigate(
+              lastFlowId
+                ? `/plan/${summary.id}?flowId=${lastFlowId}`
+                : `/plan/${summary.id}`,
+            )
+          }
+        />
 
         {/* Retention footer */}
         {retLine && (
@@ -691,10 +700,19 @@ const RepoCard = ({
               {formatBytes(bytesAdded30d)}
             </MetaItem>
           )}
+           
+              lastFlowId
+                ? `/repo/${summary.id}?flowId=${lastFlowId}
+                : `,
+            
+          
         </Flex>
 
         {/* 30-day history strip */}
-        <HistoryStrip buckets={summary.historyLast30days} />
+        <HistoryStrip
+          buckets={summary.historyLast30days}
+          onCellClick={() => navigate(`/repo/${summary.id}`)}
+        />
       </Card.Body>
     </Card.Root>
   );

--- a/webui/src/features/operations/OperationTreeView.tsx
+++ b/webui/src/features/operations/OperationTreeView.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   Box,
   Flex,
@@ -88,9 +88,13 @@ interface OpTreeNode {
 export const OperationTreeView = ({
   req,
   isPlanView,
+  selectedFlowId,
+  selectPending,
 }: React.PropsWithoutRef<{
   req: GetOperationsRequest;
   isPlanView?: boolean;
+  selectedFlowId?: string;
+  selectPending?: boolean;
 }>) => {
   const config = useConfig()[0];
   const setScreenWidth = useState(window.innerWidth)[1];
@@ -198,6 +202,8 @@ export const OperationTreeView = ({
       <DisplayOperationTree
         operations={instanceBackups}
         isPlanView={isPlanView}
+        initialSelectedFlowId={selectedFlowId}
+        selectPending={selectPending}
         onSelect={(flow) => {
           if (flow) {
             setSelectedBackupId(flow.flowID);
@@ -289,15 +295,25 @@ const DisplayOperationTree = React.memo(
     operations,
     isPlanView,
     onSelect,
+    initialSelectedFlowId,
+    selectPending,
   }: {
     operations: FlowDisplayInfo[];
     isPlanView?: boolean;
     onSelect?: (flow: FlowDisplayInfo | null) => any;
+    initialSelectedFlowId?: string;
+    selectPending?: boolean;
   }) => {
     const [treeCollection, setTreeCollection] =
       useState<TreeCollection<OpTreeNode> | null>(null);
     const [expandedValue, setExpandedValue] = useState<string[]>([]);
     const [selectedValue, setSelectedValue] = useState<string[]>([]);
+
+    const onSelectRef = useRef(onSelect);
+    useEffect(() => {
+      onSelectRef.current = onSelect;
+    });
+    const lastAppliedSelection = useRef<string | undefined>(undefined);
 
     const buildTreeData = () => {
       const leafGroupFn = (op: FlowDisplayInfo) => op.flowID.toString(16);
@@ -451,6 +467,56 @@ const DisplayOperationTree = React.memo(
 
       setExpandedValue(Array.from([...expandedValue, ...toExpand]));
     }, [operations, isPlanView]);
+
+    useEffect(() => {
+      const selectionKey =
+        initialSelectedFlowId ?? (selectPending ? "PENDING" : undefined);
+      if (!selectionKey || !treeCollection) return;
+      // Only apply an initial selection once. The treeCollection is rebuilt as
+      // new operation data arrives, but we don't want to reset the user's
+      // manual selection each time.
+      if (lastAppliedSelection.current === selectionKey) {
+        return;
+      }
+
+      const matches = (n: OpTreeNode): boolean => {
+        if (initialSelectedFlowId) {
+          return (
+            n.backup?.flowID.toString() === initialSelectedFlowId
+          );
+        }
+        if (selectPending) {
+          return n.backup?.status === OperationStatus.STATUS_PENDING;
+        }
+        return false;
+      };
+
+      const find = (
+        nodes: OpTreeNode[],
+        path: string[],
+      ): { node: OpTreeNode; path: string[] } | undefined => {
+        for (const n of nodes) {
+          if (matches(n)) {
+            return { node: n, path };
+          }
+          if (n.children) {
+            const found = find(n.children, [...path, n.id]);
+            if (found) return found;
+          }
+        }
+      };
+
+      const result = find(treeCollection.rootNode.children ?? [], []);
+      if (!result) return;
+
+      const { node, path } = result;
+      setSelectedValue([node.id]);
+      setExpandedValue((prev) =>
+        Array.from(new Set([...prev, ...path, node.id])),
+      );
+      onSelectRef.current?.(node.backup!);
+      lastAppliedSelection.current = selectionKey;
+    }, [initialSelectedFlowId, selectPending, treeCollection]);
 
     const renderNode = useCallback(
       ({ node, nodeState }: { node: OpTreeNode; nodeState: any }) =>

--- a/webui/src/features/plans/PlanView.tsx
+++ b/webui/src/features/plans/PlanView.tsx
@@ -35,7 +35,15 @@ import { OperationListView } from "../operations/OperationListView";
 import { OperationTreeView } from "../operations/OperationTreeView";
 import * as m from "../../paraglide/messages";
 
-export const PlanView = ({ plan }: React.PropsWithChildren<{ plan: Plan }>) => {
+export const PlanView = ({
+  plan,
+  selectedFlowId,
+  selectPending,
+}: React.PropsWithChildren<{
+  plan: Plan;
+  selectedFlowId?: string;
+  selectPending?: boolean;
+}>) => {
   const [config, _] = useConfig();
   const showModal = useShowModal();
   const repo = config?.repos.find((r) => r.id === plan.repo);
@@ -174,6 +182,8 @@ export const PlanView = ({ plan }: React.PropsWithChildren<{ plan: Plan }>) => {
               lastN: BigInt(MAX_OPERATION_HISTORY),
             })}
             isPlanView={true}
+            selectedFlowId={selectedFlowId}
+            selectPending={selectPending}
           />
         </TabsContent>
 

--- a/webui/src/features/repositories/RepoView.tsx
+++ b/webui/src/features/repositories/RepoView.tsx
@@ -42,7 +42,8 @@ const StatsPanel = React.lazy(() => import("../dashboard/StatsPanel"));
 
 export const RepoView = ({
   repo,
-}: React.PropsWithChildren<{ repo: RepoProps }>) => {
+  selectedFlowId,
+}: React.PropsWithChildren<{ repo: RepoProps; selectedFlowId?: string }>) => {
   const [config, _] = useConfig();
   const showModal = useShowModal();
 
@@ -215,6 +216,7 @@ export const RepoView = ({
               },
               lastN: BigInt(MAX_OPERATION_HISTORY),
             })}
+            selectedFlowId={selectedFlowId}
           />
         </TabsContent>
 


### PR DESCRIPTION
This PR adds clickable navigation from the dashboard to plan/repo detail views and auto-selects the referenced operation flow or pending operations in the operation tree.

<img width="394" height="225" alt="grafik" src="https://github.com/user-attachments/assets/da2a2b87-94d7-44c5-b35a-12c4fe594386" />

And the time line (history strip) entries are also clickable and lead to the corresponding backup:
<img width="427" height="212" alt="grafik" src="https://github.com/user-attachments/assets/499f2364-35d7-480d-b22a-e6f14e415967" />
