### PR TITLE
fix(orchestrator): pass --no-lock when listing snapshots

### DIFF
--- a/internal/orchestrator/repo/repo.go
+++ b/internal/orchestrator/repo/repo.go
@@ -105,11 +105,15 @@ func (r *RepoOrchestrator) Init(ctx context.Context) error {
 	return r.repo.Init(ctx)
 }
 
+// Snapshots and SnapshotsForPlan use --no-lock unconditionally, matching
+// ListSnapshotFiles below, to avoid cancellation-orphaned listing locks and
+// allow snapshot browsing during repository maintenance.
+// See https://github.com/garethgeorge/backrest/pull/892#discussion_r2330841541.
 func (r *RepoOrchestrator) Snapshots(ctx context.Context) ([]*restic.Snapshot, error) {
 	ctx, flush := forwardResticLogs(ctx)
 	defer flush()
 
-	snapshots, err := r.repo.Snapshots(ctx)
+	snapshots, err := r.repo.Snapshots(ctx, restic.WithFlags("--no-lock"))
 	if err != nil {
 		return nil, fmt.Errorf("get snapshots for repo %v: %w", r.repoConfig.Id, err)
 	}
@@ -126,7 +130,9 @@ func (r *RepoOrchestrator) SnapshotsForPlan(ctx context.Context, plan *v1.Plan) 
 		tags = append(tags, TagForInstance(r.config.Instance))
 	}
 
-	snapshots, err := r.repo.Snapshots(ctx, restic.WithFlags("--tag", strings.Join(tags, ",")))
+	snapshots, err := r.repo.Snapshots(ctx,
+		restic.WithFlags("--tag", strings.Join(tags, ",")),
+		restic.WithFlags("--no-lock"))
 	if err != nil {
 		return nil, fmt.Errorf("get snapshots for plan %q: %w", plan.Id, err)
 	}

--- a/internal/orchestrator/repo/repo_test.go
+++ b/internal/orchestrator/repo/repo_test.go
@@ -490,3 +490,94 @@ func TestRestoreAmbiguity(t *testing.T) {
 		t.Errorf("FAIL: Expected main file missing: %s", expectedFile)
 	}
 }
+
+// TestSnapshotListingTakesNoLock asserts that both snapshot listing paths pass
+// --no-lock. Restic is killed outright when the caller's context is cancelled,
+// so a listing that takes a lock can leave one behind, blocking forget/prune.
+//
+// This stands a recording script in for restic rather than reproducing the
+// kill, which would be timing dependent.
+func TestSnapshotListingTakesNoLock(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test substitutes a shell script for the restic binary")
+	}
+	t.Parallel()
+
+	dir := t.TempDir()
+	argsFile := filepath.Join(dir, "args")
+	resticShim := filepath.Join(dir, "restic")
+
+	// Records the arguments of each invocation, then returns an empty snapshot
+	// list so the caller parses it as valid JSON.
+	script := fmt.Sprintf("#!/bin/sh\nprintf '%%s\\0' \"$@\" > %q\necho '[]'\n", argsFile)
+	if err := os.WriteFile(resticShim, []byte(script), 0o700); err != nil {
+		t.Fatalf("write restic shim: %v", err)
+	}
+
+	orchestrator, err := NewRepoOrchestrator(configForTest, &v1.Repo{
+		Id:       "test",
+		Uri:      t.TempDir(),
+		Password: "test",
+	}, resticShim)
+	if err != nil {
+		t.Fatalf("failed to create repo orchestrator: %v", err)
+	}
+
+	// The subtests share argsFile, so they must run sequentially — do not add
+	// t.Parallel() inside t.Run.
+	for _, tc := range []struct {
+		name string
+		call func() error
+		// wantTag is the expected --tag value; empty means the listing must
+		// carry no tag filter at all.
+		wantTag string
+	}{
+		{
+			name: "Snapshots",
+			call: func() error {
+				_, err := orchestrator.Snapshots(context.Background())
+				return err
+			},
+		},
+		{
+			name: "SnapshotsForPlan",
+			call: func() error {
+				_, err := orchestrator.SnapshotsForPlan(context.Background(), &v1.Plan{
+					Id: "test", Repo: "test",
+				})
+				return err
+			},
+			wantTag: "plan:test,created-by:test",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := os.Remove(argsFile); err != nil && !os.IsNotExist(err) {
+				t.Fatalf("remove recorded args: %v", err)
+			}
+			if err := tc.call(); err != nil {
+				t.Fatalf("list snapshots: %v", err)
+			}
+			recorded, err := os.ReadFile(argsFile)
+			if err != nil {
+				t.Fatalf("read recorded args: %v", err)
+			}
+			args := strings.Split(strings.TrimSuffix(string(recorded), "\x00"), "\x00")
+			if len(args) == 0 || args[0] != "snapshots" {
+				t.Fatalf("expected snapshots command, got %q", args)
+			}
+			for _, flag := range []string{"--json", "--no-lock"} {
+				if !slices.Contains(args, flag) {
+					t.Errorf("missing %s argument: %q", flag, args)
+				}
+			}
+			tagIndex := slices.Index(args, "--tag")
+			if tc.wantTag == "" {
+				if tagIndex >= 0 {
+					t.Errorf("unexpected tag filter for repository listing: %q", args)
+				}
+			} else if tagIndex < 0 || tagIndex+1 >= len(args) || args[tagIndex+1] != tc.wantTag {
+				t.Errorf("expected tag filter %q: %q", tc.wantTag, args)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

A cancelled snapshot listing can leave a lock behind in the restic repository, which then has to be cleared by hand with `restic unlock`.

The path:

1. A client calls `ListSnapshots` (`internal/api/backresthandler.go:346`) and goes away — a browser tab closes, an HTTP client hits its timeout.
2. ConnectRPC cancels the request context.
3. That same context reaches `exec.CommandContext` in `pkg/restic/restic.go:68`, which SIGKILLs `restic` as soon as the context is done.
4. `restic snapshots` dies with no opportunity to remove the lock file it just created.

The lock restic leaves behind is non-exclusive, so backups and listings keep working and the UI stays green. Only operations that need exclusive access fail, which for Backrest means `forget` and `prune`. The repository quietly stops being pruned, and stays that way until something else surfaces it.

## Fix

Pass `--no-lock` to `Snapshots` and `SnapshotsForPlan`, unconditionally.

Listing snapshots is a read; it has no business leaving the repository locked. `ListSnapshotFiles` has done exactly this since 3850b8f ("allow browsing snapshots while repo is locked"), at `internal/orchestrator/repo/repo.go:203` on main. This extends the same treatment to the two listing paths alongside it.

This follows the [review direction left on #892](https://github.com/garethgeorge/backrest/pull/892#discussion_r2330841541) — *"Please don't pass this through, make it the default in the orchestrator. There probably isn't a scenario where we'd want to do this without --no-lock."* That PR only changed `Snapshots()`; the `ListSnapshots` RPC calls `SnapshotsForPlan` whenever a `planId` is set, which is the usual case from the UI, so both need it.

**On #526 specifically:** this doesn't change the cancellation behavior discussed there — restic is still killed outright when the context is cancelled. It removes the lock that made being killed harmful.

## A second failure the same flag fixes

Snapshot listings were run in a loop while a `forget` removed 30 snapshots from the same repository (restic 0.19.1; identical scripts, `--no-lock` the only difference between the two runs):

| listing | succeeded | failed |
| --- | --- | --- |
| `snapshots` (main) | 14 | 17 |
| `snapshots --no-lock` (this PR) | 43 | 0 |

The failures on main are exit code 11, `repository is already locked exclusively`. The probe contends much harder than real usage — it runs `forget` 30 times back to back — so the ratio shows the failure mode is easy to reach, not a production rate.

So this isn't only about orphaned locks. On main a snapshot listing can fail outright whenever a forget or prune happens to be running, which surfaces in the UI as a failed request.

## The one caller worth a second look

`Backup()` (`repo.go:137`) calls `SnapshotsForPlan` to choose a `--parent` snapshot, and now gets that list without taking a lock.

That is safe: the lock never provided cross-call protection here in the first place. The listing and the subsequent `restic backup` are separate restic processes with independent lock lifetimes — the listing's lock was already released before `backup` started. And `--parent` is a dedup optimization, not a correctness requirement: if the chosen parent is gone by the time `backup` runs, restic just scans without one.

## Verification

- `gofmt`, `go vet ./...`, `go build ./...` all clean.
- Full `go test -race ./...` green: 25 packages, 0 failures, run with the same fabricated `webui/dist` that the CI test job creates.
- Checked directly against real temporary restic repositories: on main, `restic snapshots` creates a lock file for the duration of the call, so a mid-flight kill orphans it; with `--no-lock` no lock file is created, so there is nothing left to orphan.
- `TestSnapshotListingTakesNoLock` covers both call sites as separate subtests. It points the orchestrator at a recording script instead of the restic binary — the same technique as `TestJSONCommand`, which points a repo at `bash` — and asserts each invocation is a `snapshots --json` call carrying `--no-lock`, with `SnapshotsForPlan` carrying its `--tag` filter and plain `Snapshots` carrying none. Removing `--no-lock` from either call site fails the matching subtest; so does letting `--no-lock` clobber the tag filter, or a tag leaking into the plain listing. Needs no restic binary and adds a fraction of a second. It skips on Windows for the same reason `TestJSONCommand` does: the stand-in is a shell script.

Refs #664, #892.

---

*Disclosure: written with AI assistance. The bug is one I hit on my own instance — two incidents three weeks apart — and traced from the orphaned lock back through Backrest's source. Every reference above was checked against `main`, and the test was confirmed to fail against each regression it claims to catch.*
