### PR TITLE
feat: Add rsync to alpine docker image

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,7 +1,7 @@
 FROM alpine:latest
 LABEL org.opencontainers.image.source="https://github.com/garethgeorge/backrest"
 RUN apk --no-cache add tini ca-certificates curl bash rclone openssh tzdata docker-cli && \
-    rclone selfupdate --stable
+    rsync rclone selfupdate --stable
 RUN mkdir -p /tmp
 
 ARG TARGETPLATFORM


### PR DESCRIPTION
This PR adds `rsync` to the alpine docker image.

## Context
Backrest is for many people, including me, the backup tool of choice. Using the webhooks it is possible to safely stop an application, back it up, and start the application again ( #346 ). 

Backrest can backup to many targets, but it would also be nice to also make use of the 'downtime' to make a local copy of files you might want to copy. `rsync` would allow for this (#1046).

Adding `rsync` would add roughly 500kb to the image (according to Claude). 
If you want I can also update the docs to describe this or provide examples.
